### PR TITLE
Fix dynamic MCP filesystem imports

### DIFF
--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -6,7 +6,7 @@
  */
 
 import { readFileSync, existsSync } from 'fs';
-import fs from 'fs/promises';
+import fsPromises from 'fs/promises';
 import { join, resolve } from 'path';
 import path from 'path';
 import { homedir } from 'os';
@@ -615,7 +615,7 @@ class WTFMCPManagerServer {
     }
 
     // Create FastAPI-MCP wrapper
-    const fastAPICode = code || (appPath ? await fs.readFile(appPath, 'utf-8') : '');
+    const fastAPICode = code || (appPath ? await fsPromises.readFile(appPath, 'utf-8') : '');
     const apiSpec = {
       name: options.name || 'fastapi-app',
       type: 'fastapi',
@@ -736,13 +736,13 @@ class WTFMCPManagerServer {
     // List available but not running MCPs
     const dynamicDir = this.generator.baseDir;
     try {
-      const dirs = await fs.promises.readdir(dynamicDir);
+      const dirs = await fsPromises.readdir(dynamicDir);
 
       for (const dir of dirs) {
         if (!active.find(mcp => mcp.id === dir)) {
           const configPath = path.join(dynamicDir, dir, 'config.json');
           try {
-            const config = JSON.parse(await fs.promises.readFile(configPath, 'utf-8'));
+            const config = JSON.parse(await fsPromises.readFile(configPath, 'utf-8'));
             available.push({
               ...config,
               status: 'stopped'


### PR DESCRIPTION
## Summary
- import the promise-based filesystem helper under a dedicated identifier
- update dynamic MCP handling to use the new fsPromises reference

## Testing
- node test/test-mcp-server.js

------
https://chatgpt.com/codex/tasks/task_e_68e17cbff11c832682838d6a87a9e9ef

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized asynchronous file handling across the app using a unified import approach, improving consistency and maintainability.
  * Aligns internal file access patterns for reading directories and files, supporting more predictable behavior.
  * No changes to user-facing functionality, settings, or APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->