### PR TITLE
Fix dynamic MCP listing promise usage

### DIFF
--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -736,13 +736,13 @@ class WTFMCPManagerServer {
     // List available but not running MCPs
     const dynamicDir = this.generator.baseDir;
     try {
-      const dirs = await fs.promises.readdir(dynamicDir);
+      const dirs = await fs.readdir(dynamicDir);
 
       for (const dir of dirs) {
         if (!active.find(mcp => mcp.id === dir)) {
           const configPath = path.join(dynamicDir, dir, 'config.json');
           try {
-            const config = JSON.parse(await fs.promises.readFile(configPath, 'utf-8'));
+            const config = JSON.parse(await fs.readFile(configPath, 'utf-8'));
             available.push({
               ...config,
               status: 'stopped'

--- a/test/test-mcp-server.js
+++ b/test/test-mcp-server.js
@@ -91,6 +91,21 @@ async function runTests() {
     console.log(chalk.red('❌ MCP listing failed:'), error.message);
   }
 
+  // Test 7b: List dynamic MCPs
+  console.log(chalk.yellow('\n7b. Testing dynamic MCP listing...'));
+  try {
+    const { active, available, total } = await server.handleRequest('list_dynamic_mcps');
+    if (!Array.isArray(active) || !Array.isArray(available) || typeof total !== 'number') {
+      throw new Error('Unexpected response structure');
+    }
+    console.log(chalk.green('✅ Dynamic MCP listing:'));
+    console.log(`   Active: ${active.length}`);
+    console.log(`   Available: ${available.length}`);
+    console.log(`   Total: ${total}`);
+  } catch (error) {
+    console.log(chalk.red('❌ Dynamic MCP listing failed:'), error.message);
+  }
+
   // Test 7: Diagnostics
   console.log(chalk.yellow('\n7. Testing diagnostics...'));
   try {


### PR DESCRIPTION
## Summary
- call the promise-based fs methods directly when listing dynamic MCPs
- extend the manual test script to validate the dynamic MCP listing response structure

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e17cc9bf0483269eee4446ed13e30d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fix
  * Ensures listing dynamic MCPs returns a complete, correctly structured response (active, available, total), improving stability across environments.
* Refactor
  * Streamlined internal file handling for discovering dynamic MCPs and reading configs to increase consistency and resilience.
* Tests
  * Added an automated test for server.handleRequest('list_dynamic_mcps') to verify response shape and catch issues early.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->