### PR TITLE
Fix dynamic MCP listing fs usage and add regression test

### DIFF
--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -736,13 +736,13 @@ class WTFMCPManagerServer {
     // List available but not running MCPs
     const dynamicDir = this.generator.baseDir;
     try {
-      const dirs = await fs.promises.readdir(dynamicDir);
+      const dirs = await fs.readdir(dynamicDir);
 
       for (const dir of dirs) {
         if (!active.find(mcp => mcp.id === dir)) {
           const configPath = path.join(dynamicDir, dir, 'config.json');
           try {
-            const config = JSON.parse(await fs.promises.readFile(configPath, 'utf-8'));
+            const config = JSON.parse(await fs.readFile(configPath, 'utf-8'));
             available.push({
               ...config,
               status: 'stopped'

--- a/test/test-mcp-server.js
+++ b/test/test-mcp-server.js
@@ -6,6 +6,10 @@
 
 import { WTFMCPManagerServer } from '../lib/mcp-server.js';
 import chalk from 'chalk';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import assert from 'assert/strict';
 
 async function runTests() {
   console.log(chalk.cyan('\n🧪 Testing WTF-MCP-Manager Meta Server\n'));
@@ -103,6 +107,51 @@ async function runTests() {
     });
   } catch (error) {
     console.log(chalk.red('❌ Diagnostics failed:'), error.message);
+  }
+
+  // Test 8: List Dynamic MCPs
+  console.log(chalk.yellow('\n8. Testing dynamic MCP listing...'));
+  const originalBaseDir = server.generator.baseDir;
+  const tempBaseDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wtf-dynamic-mcps-'));
+
+  try {
+    server.generator.baseDir = tempBaseDir;
+    server.generator.activeMCPs.set('active-mcp', {
+      config: { name: 'Active MCP', type: 'dynamic', port: 1234 },
+      process: { pid: 4321, kill: () => {} },
+      startTime: new Date(Date.now() - 1000)
+    });
+
+    const availableDir = path.join(tempBaseDir, 'available-mcp');
+    await fs.mkdir(availableDir, { recursive: true });
+    await fs.writeFile(path.join(availableDir, 'config.json'), JSON.stringify({
+      id: 'available-mcp',
+      name: 'Available MCP',
+      description: 'Test dynamic MCP'
+    }));
+
+    const result = await server.handleRequest('list_dynamic_mcps');
+
+    assert.ok(Array.isArray(result.active), 'Active MCPs should be an array');
+    assert.ok(Array.isArray(result.available), 'Available MCPs should be an array');
+    assert.strictEqual(result.total, result.active.length + result.available.length, 'Total should match counts');
+
+    const activeIds = result.active.map(mcp => mcp.id);
+    assert.ok(activeIds.includes('active-mcp'), 'Active MCPs should include the mocked entry');
+
+    const availableIds = result.available.map(mcp => mcp.id);
+    assert.ok(availableIds.includes('available-mcp'), 'Available MCPs should include the mocked directory');
+
+    const availableEntry = result.available.find(mcp => mcp.id === 'available-mcp');
+    assert.strictEqual(availableEntry.status, 'stopped', 'Available MCP should be marked as stopped');
+
+    console.log(chalk.green('✅ Dynamic MCP listing passed.'));
+  } catch (error) {
+    console.log(chalk.red('❌ Dynamic MCP listing failed:'), error.message);
+  } finally {
+    server.generator.baseDir = originalBaseDir;
+    server.generator.activeMCPs.clear();
+    await fs.rm(tempBaseDir, { recursive: true, force: true });
   }
 
   console.log(chalk.cyan('\n🎯 All tests completed!\n'));


### PR DESCRIPTION
## Summary
- call `fs.readdir` and `fs.readFile` directly inside `listDynamicMCPs`
- add a regression test that verifies `list_dynamic_mcps` reports active and available entries using a temporary directory

## Testing
- node test/test-mcp-server.js

------
https://chatgpt.com/codex/tasks/task_e_68e17ce5b1dc8326bde21c8e0bc190c2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when discovering and reading MCP configurations, reducing potential errors during directory scans and file loads.
* **Refactor**
  * Updated file operation approach to enhance consistency and compatibility without changing user-visible behavior.
* **Tests**
  * Added a comprehensive test for listing dynamic MCPs, validating active and available entries, counts, and statuses, with full setup/teardown.
* **Chores**
  * Enhanced test scaffolding and cleanup to ensure stable execution across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->