### PR TITLE
Fix dynamic MCP listing and add regression coverage

### DIFF
--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -736,13 +736,13 @@ class WTFMCPManagerServer {
     // List available but not running MCPs
     const dynamicDir = this.generator.baseDir;
     try {
-      const dirs = await fs.promises.readdir(dynamicDir);
+      const dirs = await fs.readdir(dynamicDir);
 
       for (const dir of dirs) {
         if (!active.find(mcp => mcp.id === dir)) {
           const configPath = path.join(dynamicDir, dir, 'config.json');
           try {
-            const config = JSON.parse(await fs.promises.readFile(configPath, 'utf-8'));
+            const config = JSON.parse(await fs.readFile(configPath, 'utf-8'));
             available.push({
               ...config,
               status: 'stopped'

--- a/test/test-mcp-server.js
+++ b/test/test-mcp-server.js
@@ -6,6 +6,9 @@
 
 import { WTFMCPManagerServer } from '../lib/mcp-server.js';
 import chalk from 'chalk';
+import { mkdtemp, rm, writeFile, mkdir } from 'fs/promises';
+import { tmpdir } from 'os';
+import path from 'path';
 
 async function runTests() {
   console.log(chalk.cyan('\n🧪 Testing WTF-MCP-Manager Meta Server\n'));
@@ -103,6 +106,47 @@ async function runTests() {
     });
   } catch (error) {
     console.log(chalk.red('❌ Diagnostics failed:'), error.message);
+  }
+
+  console.log(chalk.yellow('\n8. Testing dynamic MCP listing...'));
+  const tempDir = await mkdtemp(path.join(tmpdir(), 'wtf-mcp-manager-'));
+  const dynamicDir = path.join(tempDir, 'dynamic-mcps');
+
+  try {
+    server.generator.baseDir = dynamicDir;
+
+    const fakeMCPDir = path.join(dynamicDir, 'fake-mcp');
+    await mkdir(fakeMCPDir, { recursive: true });
+    await writeFile(
+      path.join(fakeMCPDir, 'config.json'),
+      JSON.stringify(
+        {
+          id: 'fake-mcp',
+          name: 'Fake MCP',
+          description: 'Regression test MCP',
+          type: 'test'
+        },
+        null,
+        2
+      ),
+      'utf-8'
+    );
+
+    const dynamicResult = await server.handleRequest('list_dynamic_mcps');
+    const stoppedMCP = dynamicResult.available.find(mcp => mcp.id === 'fake-mcp');
+
+    if (!stoppedMCP || stoppedMCP.status !== 'stopped') {
+      throw new Error('Fake MCP was not reported as a stopped dynamic MCP');
+    }
+
+    console.log(chalk.green('✅ Dynamic MCP listing:'));
+    console.log(`   Active: ${dynamicResult.active.length}`);
+    console.log(`   Available: ${dynamicResult.available.length}`);
+    console.log(`   Found stopped MCP: ${stoppedMCP.name} (${stoppedMCP.status})`);
+  } catch (error) {
+    console.log(chalk.red('❌ Dynamic MCP listing failed:'), error.message);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
   }
 
   console.log(chalk.cyan('\n🎯 All tests completed!\n'));


### PR DESCRIPTION
## Summary
- update listDynamicMCPs to call fs.readdir and fs.readFile directly from the fs/promises import
- add a regression test that seeds a fake dynamic MCP directory and ensures stopped MCPs are reported

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e17cece9ac8326aa3d5cb9aebb2493