### PR TITLE
Fix enabling auto-discovered MCPs

### DIFF
--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -553,7 +553,8 @@ class WTFMCPManagerServer {
 
       if (topAPI.type === 'existing-mcp') {
         // Enable existing MCP
-        await this.manager.enable(topAPI.name);
+        const registryId = this.extractMCPId(topAPI.package || topAPI.name);
+        await this.manager.enable(registryId);
         return {
           success: true,
           message: `Enabled existing MCP: ${topAPI.name}`,


### PR DESCRIPTION
## Summary
- derive the registry identifier from discovered MCP package metadata before enabling it
- ensure enable receives the canonical MCP id while the response preserves the original package details

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e17d7da51483269b204cec3a4c351b