### PR TITLE
Fix dynamic MCP listing to use fs module correctly

### DIFF
--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -736,13 +736,13 @@ class WTFMCPManagerServer {
     // List available but not running MCPs
     const dynamicDir = this.generator.baseDir;
     try {
-      const dirs = await fs.promises.readdir(dynamicDir);
+      const dirs = await fs.readdir(dynamicDir);
 
       for (const dir of dirs) {
         if (!active.find(mcp => mcp.id === dir)) {
           const configPath = path.join(dynamicDir, dir, 'config.json');
           try {
-            const config = JSON.parse(await fs.promises.readFile(configPath, 'utf-8'));
+            const config = JSON.parse(await fs.readFile(configPath, 'utf-8'));
             available.push({
               ...config,
               status: 'stopped'


### PR DESCRIPTION
## Summary
- update the dynamic MCP listing helper to call readdir and readFile directly on the fs/promises import
- ensure the listing logic can enumerate directories without triggering a TypeError

## Testing
- node --input-type=module - <<'NODE'
import { WTFMCPManagerServer } from './lib/mcp-server.js';

const server = new WTFMCPManagerServer();
const result = await server.listDynamicMCPs();
console.log(JSON.stringify(result, null, 2));
NODE


------
https://chatgpt.com/codex/tasks/task_e_68e17d7c22fc832684f60198b8d2c11d