### PR TITLE
Resolve dynamic MCP server config to use absolute path

### DIFF
--- a/lib/dynamic/mcp-generator.js
+++ b/lib/dynamic/mcp-generator.js
@@ -244,7 +244,10 @@ if __name__ == "__main__":
     const code = await this.generateCode(apiSpec, template);
 
     // Write MCP server file
-    const serverFile = path.join(mcpDir, `server.${template.language === 'python' ? 'py' : 'js'}`);
+    const serverFile = path.resolve(
+      mcpDir,
+      `server.${template.language === 'python' ? 'py' : 'js'}`
+    );
     await fs.writeFile(serverFile, code);
     await fs.chmod(serverFile, 0o755);
 


### PR DESCRIPTION
## Summary
- use `path.resolve` when generating MCP server files so configs record absolute paths
- continue to launch servers via the resolved file path to avoid cwd-related failures

## Testing
- `node --input-type=module <<'NODE' ... NODE`


------
https://chatgpt.com/codex/tasks/task_e_68e17d6cc4648326adaccea5ac9de6f9