### PR TITLE
Fix promise-based fs usage in dynamic MCP listing

### DIFF
--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -736,13 +736,13 @@ class WTFMCPManagerServer {
     // List available but not running MCPs
     const dynamicDir = this.generator.baseDir;
     try {
-      const dirs = await fs.promises.readdir(dynamicDir);
+      const dirs = await fs.readdir(dynamicDir);
 
       for (const dir of dirs) {
         if (!active.find(mcp => mcp.id === dir)) {
           const configPath = path.join(dynamicDir, dir, 'config.json');
           try {
-            const config = JSON.parse(await fs.promises.readFile(configPath, 'utf-8'));
+            const config = JSON.parse(await fs.readFile(configPath, 'utf-8'));
             available.push({
               ...config,
               status: 'stopped'


### PR DESCRIPTION
## Summary
- update listDynamicMCPs to use the promise-based fs module directly
- ensure dynamic MCP discovery handles both running and stopped entries without errors

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e17d6a58bc8326a1e0f29a3f66dd00