### PR TITLE
Fix default export wiring for MCP manager

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,13 @@
 /**
  * WTF-MCP-Manager Main Entry Point
  */
+import { MCPManager } from './manager.js';
+import { MCPRegistry } from './registry.js';
+import { AutoDetector } from './detector.js';
 
-export { MCPManager } from './manager.js';
-export { MCPRegistry } from './registry.js';
-export { AutoDetector } from './detector.js';
+export { MCPManager };
+export { MCPRegistry };
+export { AutoDetector };
 
 // Re-export for convenience
 export default {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.1.0",
   "description": "🎯 Smart MCP Manager for Claude - Enable/disable MCPs per project",
   "main": "lib/index.js",
+  "exports": {
+    ".": "./lib/index.js"
+  },
   "type": "module",
   "bin": {
     "wtf-mcp-manager": "./bin/wtf-mcp.js",

--- a/test/import.test.js
+++ b/test/import.test.js
@@ -1,0 +1,19 @@
+import pkg, { MCPManager, MCPRegistry, AutoDetector } from 'wtf-mcp-manager';
+
+if (!pkg) {
+  throw new Error('Default export missing');
+}
+
+if (pkg.MCPManager !== MCPManager) {
+  throw new Error('MCPManager mismatch');
+}
+
+if (pkg.MCPRegistry !== MCPRegistry) {
+  throw new Error('MCPRegistry mismatch');
+}
+
+if (pkg.AutoDetector !== AutoDetector) {
+  throw new Error('AutoDetector mismatch');
+}
+
+console.log('Default and named exports are consistent.');


### PR DESCRIPTION
## Summary
- import MCPManager, MCPRegistry, and AutoDetector before re-exporting them in the entrypoint
- expose the package entry via the exports map to support self-referential imports
- add a smoke test that ensures `import pkg from 'wtf-mcp-manager'` returns the expected bindings

## Testing
- node test/import.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e17d6141908326a8aeea3e250e0946