### PR TITLE
docs: update README to reflect current dynamic generation status

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,28 +3,40 @@
 [![npm version](https://badge.fury.io/js/wtf-mcp-manager.svg)](https://badge.fury.io/js/wtf-mcp-manager)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-> **🚀 NEW v2.0: Dynamic MCP Generation!** Create MCPs from ANY API on-the-fly. Just tell Claude what you need: "I need weather data" → MCP generated instantly from any weather API!
+> **Status: v1.1.0 (experimental dynamic generation)**  
+> The current release ships a heuristic discovery pipeline and a template-based MCP generator. Automated Gorilla discovery, workflow orchestration, and end-to-end testing are still on the roadmap.
 
-## 🤯 The Magic: Dynamic MCP Generation
+## 🤯 What Dynamic Generation Means Today
 
-**v2.0 - Generate MCPs from ANY API instantly!**
+The `lib/discovery/api-discovery.js` module combines several pragmatic heuristics to propose candidate APIs:
 
-### ✨ New Capabilities
+- 🔎 **Curated Database Search** – Queries the local API catalog shipped in `lib/discovery/api-database.js` for quick matches.
+- 🌐 **Public Registry Lookups** – Pulls data from APIs.guru and other public indexes when network access is available.
+- 🐙 **GitHub Repository Scan** – Hits the GitHub search endpoint for repos whose descriptions mention the requested capability.
+- 🧭 **Domain Hints** – Falls back to the hard-coded maritime/weather catalog in `lib/discovery/web-search.js` when web search APIs require keys.
 
-- 🎯 **Dynamic Generation**: Create MCPs from any API specification
-- 🔍 **Intelligent Discovery**: Find APIs using Gorilla API & web scraping
-- 🚀 **Zero Config**: Generate and deploy MCPs without writing code
-- 🔄 **Multi-MCP Workflows**: Compose multiple MCPs into workflows
-- 🧪 **Auto-Testing**: Validate generated MCPs automatically
+These sources are merged, deduplicated, and scored before being returned to Claude. The Gorilla API endpoint is referenced in code but not yet wired up with authentication or ranking, so Gorilla-powered discovery remains future work.
 
-### 💬 Just Chat Naturally
+## 🛠️ Template-Based MCP Generation
 
-- **"I need weather data"** → Discovers weather APIs, generates MCP instantly
-- **"Connect to my FastAPI app"** → Converts your FastAPI to MCP automatically
-- **"Find API for stock prices"** → Discovers and creates stock market MCP
-- **"Sync data between services"** → Creates multi-MCP workflow
+`lib/dynamic/mcp-generator.js` renders language-specific templates from `lib/templates/` to build runnable MCP servers on the fly, and `lib/mcp-server.js` exposes that generator through the MCP protocol. Today this means:
 
-**One MCP to rule them all - Install once, generate infinite MCPs!**
+- ✨ **Template Rendering** – REST, FastAPI, GraphQL, and WebSocket scaffolds interpolate API metadata into ready-to-run projects.
+- 🗂️ **Local File Output** – Generated servers are stored under `.claude/dynamic-mcps/` with simple lifecycle tracking.
+- 🧰 **Manual Review Expected** – Generated code focuses on shape and wiring; authentication, pagination, and schema validation still require human tweaks.
+
+### Current Limitations
+
+- 🚫 No Gorilla API integration yet, so discovery relies on local heuristics and public registries.
+- ⚙️ No automatic end-to-end verification—the repository’s Node-based smoke test does not exercise generated MCPs.
+- 🔄 Multi-MCP workflows, zero-config deployment, and other roadmap items described in earlier drafts have not been implemented.
+
+### Roadmap Highlights
+
+- Integrate Gorilla search once API access is available.
+- Expand `web-search.js` beyond maritime/weather shortcuts to real web queries.
+- Add automated regression tests for the generator output and live MCP lifecycle.
+- Revisit workflow orchestration once the generation pipeline is battle-tested.
 
 ---
 


### PR DESCRIPTION
## Summary
- replace the outdated v2.0 marketing copy with a description of the current 1.1.0 heuristic discovery pipeline
- explain how the template-driven generator and MCP server work today and call out their limitations
- align README version references with the package metadata

## Testing
- not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e17d542aa88326ad7af153ae1dcb7c