### PR TITLE
Handle existing MCP auto-create with canonical IDs

### DIFF
--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -238,6 +238,7 @@ class WTFMCPManagerServer {
     return name
       .replace(/^(mcp-)?server-/, '')
       .replace(/-mcp-server$/, '')
+      .replace(/@[^@/]+$/, '')
       .replace(/^@[\w-]+\//, '');
   }
 
@@ -553,11 +554,32 @@ class WTFMCPManagerServer {
 
       if (topAPI.type === 'existing-mcp') {
         // Enable existing MCP
-        await this.manager.enable(topAPI.name);
+        const derivedId = this.extractMCPId(topAPI.package || topAPI.name);
+
+        if (!derivedId) {
+          return {
+            success: false,
+            message: `Could not determine MCP identifier for ${topAPI.name}`,
+            mcp: topAPI
+          };
+        }
+
+        const registryEntry = this.registry.get(derivedId);
+
+        if (!registryEntry) {
+          return {
+            success: false,
+            message: `MCP "${topAPI.name}" (${derivedId}) is not available in the local registry`,
+            recommendation: 'Update the registry or register the MCP manually before enabling.',
+            mcp: topAPI
+          };
+        }
+
+        await this.manager.enable(derivedId);
         return {
           success: true,
-          message: `Enabled existing MCP: ${topAPI.name}`,
-          mcp: topAPI
+          message: `Enabled existing MCP: ${registryEntry.name || topAPI.name}`,
+          mcp: { ...topAPI, id: derivedId }
         };
       } else {
         // Generate new MCP

--- a/test/test-mcp-server.js
+++ b/test/test-mcp-server.js
@@ -105,6 +105,44 @@ async function runTests() {
     console.log(chalk.red('❌ Diagnostics failed:'), error.message);
   }
 
+  // Test 8: Auto-create enabling existing MCP
+  console.log(chalk.yellow('\n8. Testing auto-create for existing MCP...'));
+  try {
+    const autoServer = new WTFMCPManagerServer();
+    const fakeAPI = {
+      type: 'existing-mcp',
+      name: 'Supabase',
+      package: '@supabase/mcp-server-supabase'
+    };
+
+    let enabledId = null;
+
+    autoServer.discovery.discoverAPIs = async () => [fakeAPI];
+    autoServer.manager.enable = async (mcpId) => {
+      enabledId = mcpId;
+      return { id: mcpId };
+    };
+    autoServer.registry.get = (mcpId) => {
+      if (mcpId === 'supabase') {
+        return { name: 'Supabase', command: 'npx', args: [] };
+      }
+      return null;
+    };
+
+    const result = await autoServer.discoverOrCreateMCP({
+      query: 'supabase',
+      autoCreate: true
+    });
+
+    if (result.success && enabledId === 'supabase') {
+      console.log(chalk.green('✅ Auto-create successfully enabled existing MCP with canonical ID.'));
+    } else {
+      console.log(chalk.red('❌ Auto-create did not enable the expected MCP ID.'), result);
+    }
+  } catch (error) {
+    console.log(chalk.red('❌ Auto-create existing MCP test failed:'), error.message);
+  }
+
   console.log(chalk.cyan('\n🎯 All tests completed!\n'));
 }
 


### PR DESCRIPTION
## Summary
- derive canonical MCP IDs when auto-creating existing MCPs and validate registry entries before enabling
- strip package version suffixes when extracting canonical IDs
- extend the MCP server test script to cover the auto-create enablement flow with a stubbed existing MCP

## Testing
- node test/test-mcp-server.js

------
https://chatgpt.com/codex/tasks/task_e_68e17d6ba9408326a3ee7f7c8d6e9c57