### PR TITLE
Generate stub tool handlers for dynamic MCP servers

### DIFF
--- a/lib/dynamic/mcp-generator.js
+++ b/lib/dynamic/mcp-generator.js
@@ -94,6 +94,8 @@ class {{CLASS_NAME}}MCPServer {
     {{RESOURCES_SETUP}}
   }
 
+  {{TOOL_METHODS}}
+
   async handleRequest(method, params = {}) {
     try {
       switch (method) {
@@ -294,9 +296,10 @@ if __name__ == "__main__":
     code = code.replace(/{{PORT}}/g, this.portCounter);
 
     // Generate tools from endpoints
-    const tools = this.generateTools(apiSpec);
+    const tools = this.generateTools(apiSpec, template.type);
     code = code.replace(/{{TOOLS_SETUP}}/g, tools.setup);
     code = code.replace(/{{REQUEST_HANDLERS}}/g, tools.handlers);
+    code = code.replace(/{{TOOL_METHODS}}/g, tools.methods);
 
     // Generate resources
     const resources = this.generateResources(apiSpec);
@@ -311,9 +314,10 @@ if __name__ == "__main__":
     return code;
   }
 
-  generateTools(apiSpec) {
+  generateTools(apiSpec, templateType = 'rest') {
     const tools = [];
     const handlers = [];
+    const methods = [];
 
     if (apiSpec.endpoints) {
       apiSpec.endpoints.forEach(endpoint => {
@@ -329,13 +333,42 @@ if __name__ == "__main__":
         handlers.push(`
         case '${toolName}':
           return await this.${toolName}(params);`);
+
+        methods.push(this.generateToolMethod(templateType, toolName, endpoint));
       });
     }
 
     return {
-      setup: tools.join('\n'),
-      handlers: handlers.join('\n')
+      setup: tools.join('\n') || '    // No tools generated yet',
+      handlers: handlers.join('\n') || '',
+      methods: methods.filter(Boolean).join('\n\n') || '  // No tool methods generated yet'
     };
+  }
+
+  generateToolMethod(templateType, toolName, endpoint = {}) {
+    const method = (endpoint.method || 'GET').toUpperCase();
+    const path = endpoint.path || '/';
+
+    if (templateType === 'graphql') {
+      const operationName = endpoint.operationName || endpoint.name || toolName;
+      return `  async ${toolName}(params = {}) {
+    return {
+      success: true,
+      message: 'Stub GraphQL operation ${operationName}',
+      operation: '${operationName}',
+      received: params
+    };
+  }`;
+    }
+
+    return `  async ${toolName}(params = {}) {
+    return {
+      success: true,
+      message: '${method} ${path} stub response',
+      endpoint: { method: '${method}', path: '${path}' },
+      received: params
+    };
+  }`;
   }
 
   generateResources(apiSpec) {

--- a/lib/templates/graphql.js.template
+++ b/lib/templates/graphql.js.template
@@ -44,6 +44,8 @@ class {{CLASS_NAME}}MCPServer {
     }
   }
 
+  {{TOOL_METHODS}}
+
   async handleRequest(method, params = {}) {
     try {
       switch (method) {

--- a/lib/templates/rest-api.js.template
+++ b/lib/templates/rest-api.js.template
@@ -21,6 +21,8 @@ class {{CLASS_NAME}}MCPServer {
     {{TOOLS_SETUP}}
   }
 
+  {{TOOL_METHODS}}
+
   async handleRequest(method, params = {}) {
     try {
       switch (method) {


### PR DESCRIPTION
## Summary
- extend the dynamic MCP generator to build stub tool handler methods for every discovered endpoint and inject them via the TOOL_METHODS placeholder
- update the REST and GraphQL templates so generated servers include the new handler implementations within their classes

## Testing
- npm test
- node - <<'NODE' ... (sample generation script to ensure tools/call succeeds)


------
https://chatgpt.com/codex/tasks/task_e_68e17d62fa9083268ffc89fdf81d5827