### PR TITLE
Add context router for tool metadata routing

### DIFF
--- a/bin/wtf-mcp.js
+++ b/bin/wtf-mcp.js
@@ -229,6 +229,76 @@ program
     }
   });
 
+// Route tools command
+program
+  .command('route-tools <tools...>')
+  .description('Format retriever results into tool metadata for context injection')
+  .option('-k, --top <number>', 'Maximum number of tools to include')
+  .action(async (tools, options) => {
+    showBanner();
+
+    const spinner = ora('Routing tool metadata...').start();
+
+    try {
+      const { WTFMCPManagerServer } = await import('../lib/mcp-server.js');
+      const server = new WTFMCPManagerServer();
+
+      const limit = options.top !== undefined ? parseInt(options.top, 10) : undefined;
+
+      if (options.top !== undefined && Number.isNaN(limit)) {
+        spinner.fail(chalk.red('Top must be a number'));
+        process.exit(1);
+      }
+
+      const retrieverResults = tools.map((tool, index) => ({
+        id: tool,
+        score: Math.max(tools.length - index, 1)
+      }));
+
+      const payload = { results: retrieverResults };
+      if (limit !== undefined) {
+        payload.limit = limit;
+      }
+
+      const routed = await server.handleRequest('route_tools', payload);
+
+      if (routed.error) {
+        throw new Error(routed.error);
+      }
+
+      spinner.succeed(chalk.green('Tool metadata ready!'));
+
+      console.log(chalk.cyan('\n🔧 Selected tools:\n'));
+      if (routed.tools.length === 0) {
+        console.log(chalk.yellow('No matching tools found for the provided results.'));
+      } else {
+        routed.tools.forEach((tool, idx) => {
+          console.log(chalk.green(`${idx + 1}. ${tool.name}`));
+          if (tool.description) {
+            console.log(chalk.gray(`   ${tool.description}`));
+          }
+        });
+      }
+
+      if (routed.examples.length > 0) {
+        console.log(chalk.cyan('\n📘 Relevant examples:\n'));
+        routed.examples.forEach(example => {
+          console.log(chalk.white(`• ${example.user}`));
+          if (example.assistant) {
+            console.log(chalk.gray(`  ${example.assistant}`));
+          }
+        });
+      }
+
+      if (routed.meta?.missing?.length) {
+        console.log(chalk.yellow(`\n⚠️  Missing tool definitions: ${routed.meta.missing.join(', ')}`));
+      }
+    } catch (error) {
+      spinner.fail(chalk.red('Failed to route tools: ' + error.message));
+      process.exit(1);
+    }
+  });
+
 // Serve command (Meta-MCP)
 program
   .command('serve')

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,10 +5,12 @@
 export { MCPManager } from './manager.js';
 export { MCPRegistry } from './registry.js';
 export { AutoDetector } from './detector.js';
+export { ContextRouter } from './router/context-router.js';
 
 // Re-export for convenience
 export default {
   MCPManager,
   MCPRegistry,
-  AutoDetector
+  AutoDetector,
+  ContextRouter
 };

--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -15,6 +15,7 @@ import { MCPRegistry } from './registry.js';
 import { AutoDetector } from './detector.js';
 import { DynamicMCPGenerator } from './dynamic/mcp-generator.js';
 import { APIDiscoveryService } from './discovery/api-discovery.js';
+import { ContextRouter } from './router/context-router.js';
 
 class WTFMCPManagerServer {
   constructor() {
@@ -28,6 +29,7 @@ class WTFMCPManagerServer {
     this.FETCH_CACHE_TTL = 30 * 60 * 1000; // 30 minutes
     this.dynamicMCPs = new Map();
     this.workflows = new Map();
+    this.contextRouter = new ContextRouter();
   }
 
   async initialize() {
@@ -389,6 +391,26 @@ class WTFMCPManagerServer {
 
         case 'stop_dynamic_mcp':
           return await this.stopDynamicMCP(params.mcpId);
+
+        case 'route_tools': {
+          const results = Array.isArray(params.results)
+            ? params.results
+            : Array.isArray(params.tools)
+              ? params.tools
+              : [];
+
+          if (!Array.isArray(results) || results.length === 0) {
+            throw new Error('route_tools requires a non-empty results array');
+          }
+
+          const limit = params.limit ?? params.topK ?? params.k;
+          const options = {};
+          if (Number.isFinite(limit) && limit >= 0) {
+            options.limit = Math.floor(limit);
+          }
+
+          return this.contextRouter.route(results, options);
+        }
 
         default:
           throw new Error(`Unknown method: ${method}`);
@@ -945,6 +967,35 @@ async function runMCPServer() {
                         }
                       },
                       required: ["query"],
+                      additionalProperties: false
+                    }
+                  },
+                  {
+                    name: "route_tools",
+                    description: "Format top retriever results into tool schemas and examples for context injection",
+                    inputSchema: {
+                      type: "object",
+                      properties: {
+                        results: {
+                          type: "array",
+                          description: "Retriever results containing tool identifiers",
+                          items: {
+                            type: "object",
+                            properties: {
+                              id: { type: "string" },
+                              name: { type: "string" },
+                              tool: { type: "string" },
+                              score: { type: ["number", "string"] }
+                            },
+                            additionalProperties: true
+                          }
+                        },
+                        limit: {
+                          type: "integer",
+                          description: "Maximum number of tools to include in the response"
+                        }
+                      },
+                      required: ["results"],
                       additionalProperties: false
                     }
                   },

--- a/lib/router/context-router.js
+++ b/lib/router/context-router.js
@@ -1,0 +1,94 @@
+import toolsData from '../../mcp-tools.json' with { type: 'json' };
+
+const clone = (value) => {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value));
+};
+
+const normalizeToolId = (candidate) => {
+  if (!candidate) {
+    return null;
+  }
+
+  if (typeof candidate === 'string') {
+    return candidate.trim() || null;
+  }
+
+  if (typeof candidate === 'object') {
+    const direct = candidate.tool || candidate.name || candidate.id || candidate.toolName;
+    if (direct && typeof direct === 'string') {
+      return direct.trim() || null;
+    }
+
+    const metadataTool = candidate.metadata?.tool || candidate.metadata?.name;
+    if (metadataTool && typeof metadataTool === 'string') {
+      return metadataTool.trim() || null;
+    }
+  }
+
+  return null;
+};
+
+export class ContextRouter {
+  constructor(options = {}) {
+    this.data = options.toolsData ? clone(options.toolsData) : toolsData;
+    this.toolIndex = new Map((this.data.tools || []).map(tool => [tool.name, tool]));
+  }
+
+  route(results = [], options = {}) {
+    if (!Array.isArray(results)) {
+      throw new Error('route_tools requires an array of retriever results');
+    }
+
+    const limitOption = options.limit ?? options.topK ?? options.k;
+    const limit = Number.isFinite(limitOption) && limitOption >= 0 ? Math.floor(limitOption) : undefined;
+
+    const requested = [];
+    for (const result of results) {
+      const toolId = normalizeToolId(result);
+      if (!toolId) {
+        continue;
+      }
+      if (!requested.includes(toolId)) {
+        requested.push(toolId);
+      }
+    }
+
+    const selected = [];
+    const missing = [];
+
+    for (const toolId of requested) {
+      if (limit !== undefined && selected.length >= limit) {
+        break;
+      }
+
+      const tool = this.toolIndex.get(toolId);
+      if (tool) {
+        selected.push(clone(tool));
+      } else {
+        missing.push(toolId);
+      }
+    }
+
+    const selectedNames = new Set(selected.map(tool => tool.name));
+    const examples = (this.data.examples || [])
+      .filter(example => Array.isArray(example.tool_calls) && example.tool_calls.some(call => selectedNames.has(call.tool)))
+      .map(example => clone(example));
+
+    return {
+      tools: selected,
+      examples,
+      meta: {
+        requested: results.length,
+        uniqueRequested: requested.length,
+        returned: selected.length,
+        limit: limit ?? null,
+        missing
+      }
+    };
+  }
+}
+
+export default ContextRouter;

--- a/test/test-mcp-server.js
+++ b/test/test-mcp-server.js
@@ -105,6 +105,40 @@ async function runTests() {
     console.log(chalk.red('❌ Diagnostics failed:'), error.message);
   }
 
+  // Test 8: Route tools
+  console.log(chalk.yellow('\n8. Testing tool routing...'));
+  try {
+    const routed = await server.handleRequest('route_tools', {
+      results: [
+        { id: 'analyze_environment', score: 0.99 },
+        { id: 'enable_mcp', score: 0.95 },
+        { id: 'fetch_mcps', score: 0.9 }
+      ],
+      limit: 2
+    });
+
+    const toolNames = routed.tools.map(tool => tool.name);
+    const unexpected = toolNames.filter(name => !['analyze_environment', 'enable_mcp'].includes(name));
+
+    if (routed.tools.length !== 2 || unexpected.length > 0) {
+      throw new Error('Route tools did not return the expected top-k tool schemas');
+    }
+
+    const exampleTools = new Set();
+    routed.examples.forEach(example => {
+      (example.tool_calls || []).forEach(call => exampleTools.add(call.tool));
+    });
+
+    const invalidExampleTools = Array.from(exampleTools).filter(tool => !toolNames.includes(tool));
+    if (invalidExampleTools.length > 0) {
+      throw new Error(`Examples include unexpected tools: ${invalidExampleTools.join(', ')}`);
+    }
+
+    console.log(chalk.green('✅ Tool routing returns only the requested top-k tool metadata.'));
+  } catch (error) {
+    console.log(chalk.red('❌ Tool routing failed:'), error.message);
+  }
+
   console.log(chalk.cyan('\n🎯 All tests completed!\n'));
 }
 


### PR DESCRIPTION
## Summary
- add a ContextRouter that formats retriever results into minimal tool schemas and examples
- expose a new route_tools RPC in the MCP server and list it for clients, plus a CLI helper command
- extend tests to verify only top-k tool details are returned and export the router from the library

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e17cd8a8008326b49730812f8ff5c7