### PR TITLE
Fix fs usage in dynamic MCP listing

### DIFF
--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -736,13 +736,13 @@ class WTFMCPManagerServer {
     // List available but not running MCPs
     const dynamicDir = this.generator.baseDir;
     try {
-      const dirs = await fs.promises.readdir(dynamicDir);
+      const dirs = await fs.readdir(dynamicDir);
 
       for (const dir of dirs) {
         if (!active.find(mcp => mcp.id === dir)) {
           const configPath = path.join(dynamicDir, dir, 'config.json');
           try {
-            const config = JSON.parse(await fs.promises.readFile(configPath, 'utf-8'));
+            const config = JSON.parse(await fs.readFile(configPath, 'utf-8'));
             available.push({
               ...config,
               status: 'stopped'


### PR DESCRIPTION
## Summary
- update the dynamic MCP listing helper to use the fs/promises methods that were already imported
- ensure listDynamicMCPs reads directories and configs without referencing fs.promises

## Testing
- node --input-type=module - <<'NODE'
import { WTFMCPManagerServer } from './lib/mcp-server.js';

const server = new WTFMCPManagerServer();
const result = await server.listDynamicMCPs();
console.log(JSON.stringify(result, null, 2));
NODE


------
https://chatgpt.com/codex/tasks/task_e_68e17e0bd5408326b405a01451603f4c