### PR TITLE
Handle registry lookup before enabling discovered MCPs

### DIFF
--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -552,12 +552,23 @@ class WTFMCPManagerServer {
       const topAPI = discovered[0];
 
       if (topAPI.type === 'existing-mcp') {
+        const registryIdSource = topAPI.package || topAPI.name;
+        const mcpId = registryIdSource ? this.extractMCPId(registryIdSource) : null;
+        const registryInfo = mcpId ? this.registry.get(mcpId) : null;
+
+        if (!registryInfo) {
+          return {
+            success: false,
+            message: `Discovered MCP "${topAPI.name}" is not available in the registry. Cannot enable automatically.`
+          };
+        }
+
         // Enable existing MCP
-        await this.manager.enable(topAPI.name);
+        await this.manager.enable(mcpId);
         return {
           success: true,
-          message: `Enabled existing MCP: ${topAPI.name}`,
-          mcp: topAPI
+          message: `Enabled existing MCP: ${registryInfo.name || mcpId}`,
+          mcp: { ...topAPI, id: mcpId }
         };
       } else {
         // Generate new MCP

--- a/test/test-mcp-server.js
+++ b/test/test-mcp-server.js
@@ -105,6 +105,40 @@ async function runTests() {
     console.log(chalk.red('❌ Diagnostics failed:'), error.message);
   }
 
+  // Test 8: Auto-create existing MCP flow
+  console.log(chalk.yellow('\n8. Testing auto-create with existing MCP...'));
+  const originalDiscoverAPIs = server.discovery.discoverAPIs;
+  const originalEnable = server.manager.enable;
+  try {
+    let enabledId = null;
+    server.discovery.discoverAPIs = async () => ([{
+      type: 'existing-mcp',
+      name: '@modelcontextprotocol/server-github',
+      package: '@modelcontextprotocol/server-github'
+    }]);
+    server.manager.enable = async (id) => {
+      enabledId = id;
+      return { id, name: 'GitHub' };
+    };
+
+    const result = await server.discoverOrCreateMCP({ query: 'github', autoCreate: true });
+
+    if (enabledId !== 'github') {
+      throw new Error(`Expected enable to be called with "github", received "${enabledId}"`);
+    }
+
+    if (!result.success) {
+      throw new Error('Expected successful response when enabling existing MCP');
+    }
+
+    console.log(chalk.green(`✅ Auto-create enabled MCP: ${enabledId}`));
+  } catch (error) {
+    console.log(chalk.red('❌ Auto-create existing MCP failed:'), error.message);
+  } finally {
+    server.discovery.discoverAPIs = originalDiscoverAPIs;
+    server.manager.enable = originalEnable;
+  }
+
   console.log(chalk.cyan('\n🎯 All tests completed!\n'));
 }
 


### PR DESCRIPTION
## Summary
- derive the registry identifier from discovered existing MCP metadata before enabling
- guard against missing registry entries with a descriptive response instead of throwing
- extend the test script to cover the auto-create flow with an existing MCP discovery stub

## Testing
- node test/test-mcp-server.js

------
https://chatgpt.com/codex/tasks/task_e_68e17e0d09588326aac1d0668b5ded2e