### PR TITLE
Ensure generated MCP servers launch using absolute paths

### DIFF
--- a/lib/dynamic/mcp-generator.js
+++ b/lib/dynamic/mcp-generator.js
@@ -244,7 +244,10 @@ if __name__ == "__main__":
     const code = await this.generateCode(apiSpec, template);
 
     // Write MCP server file
-    const serverFile = path.join(mcpDir, `server.${template.language === 'python' ? 'py' : 'js'}`);
+    const serverFile = path.resolve(
+      mcpDir,
+      `server.${template.language === 'python' ? 'py' : 'js'}`
+    );
     await fs.writeFile(serverFile, code);
     await fs.chmod(serverFile, 0o755);
 
@@ -499,10 +502,11 @@ async def ${funcName}(${this.generateParams(endpoint.parameters)}):
 
   startMCPProcess(config) {
     const command = config.language === 'python' ? 'python' : 'node';
-    const args = [config.serverFile];
+    const serverPath = path.resolve(config.serverFile);
+    const args = [path.basename(serverPath)];
 
     const process = spawn(command, args, {
-      cwd: path.dirname(config.serverFile),
+      cwd: path.dirname(serverPath),
       stdio: ['pipe', 'pipe', 'pipe']
     });
 


### PR DESCRIPTION
## Summary
- store the generated server file path as an absolute location in dynamic MCP configs
- resolve the server path before spawning processes so they launch reliably from their working directory

## Testing
- node --input-type=module <<'NODE'
import { DynamicMCPGenerator } from './lib/dynamic/mcp-generator.js';

const generator = new DynamicMCPGenerator('.tmp-dynamic-mcps');
await generator.init();
const config = await generator.generateFromAPI({
  name: 'Test API',
  baseUrl: 'https://example.com',
  endpoints: [
    { path: '/ping', description: 'Ping endpoint', method: 'GET' }
  ]
});
console.log('Generated config server file:', config.serverFile);
const proc = generator.startMCPProcess(config);
await new Promise((resolve, reject) => {
  const timer = setTimeout(resolve, 500);
  proc.once('error', (err) => {
    clearTimeout(timer);
    reject(err);
  });
});
proc.kill();
console.log('Process spawned and terminated.');
NODE

------
https://chatgpt.com/codex/tasks/task_e_68e17e0f1b9c8326beb053df24ef1005