### PR TITLE
Add vector retriever for MCP search

### DIFF
--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -15,6 +15,7 @@ import { MCPRegistry } from './registry.js';
 import { AutoDetector } from './detector.js';
 import { DynamicMCPGenerator } from './dynamic/mcp-generator.js';
 import { APIDiscoveryService } from './discovery/api-discovery.js';
+import { MCPVectorRetriever, VectorStoreUnavailableError } from './router/retriever.js';
 
 class WTFMCPManagerServer {
   constructor() {
@@ -23,6 +24,7 @@ class WTFMCPManagerServer {
     this.detector = new AutoDetector();
     this.generator = new DynamicMCPGenerator();
     this.discovery = new APIDiscoveryService();
+    this.retriever = new MCPVectorRetriever();
     this.availableMCPs = null;
     this.lastFetchTime = null;
     this.FETCH_CACHE_TTL = 30 * 60 * 1000; // 30 minutes
@@ -432,26 +434,56 @@ class WTFMCPManagerServer {
       this.availableMCPs = this.registry.getAll();
     }
 
+    if (this.retriever?.isEnabled()) {
+      try {
+        const vectorResults = await this.retriever.retrieve(query, { topK: 10 });
+        if (vectorResults.length > 0) {
+          return vectorResults;
+        }
+      } catch (error) {
+        if (error instanceof VectorStoreUnavailableError) {
+          console.warn('⚠️  Vector store unavailable, falling back to keyword search:', error.message);
+        } else {
+          console.error('Vector store retrieval failed, falling back to keyword search:', error);
+        }
+      }
+    }
+
+    return this.keywordFallbackSearch(query, 5);
+  }
+
+  keywordFallbackSearch(query, limit = 5) {
+    if (!query || !query.trim()) {
+      return [];
+    }
+
     const keywords = query.toLowerCase().split(/\s+/).filter(w => w.length > 2);
+
+    if (keywords.length === 0) {
+      return [];
+    }
+
     const results = [];
 
     for (const [id, mcp] of Object.entries(this.availableMCPs)) {
       let score = 0;
 
-      keywords.forEach(keyword => {
+      for (const keyword of keywords) {
         if (mcp.name && mcp.name.toLowerCase().includes(keyword)) score += 3;
         if (mcp.description && mcp.description.toLowerCase().includes(keyword)) score += 2;
         if (mcp.categories && Array.isArray(mcp.categories) &&
-            mcp.categories.some(cat => cat.includes(keyword))) score += 2;
-        if (id.includes(keyword)) score += 1;
-      });
+            mcp.categories.some(cat => typeof cat === 'string' && cat.toLowerCase().includes(keyword))) score += 2;
+        if (id.toLowerCase().includes(keyword)) score += 1;
+      }
 
       if (score > 0) {
-        results.push({ ...mcp, score });
+        results.push({ ...mcp, score, relevance: score, source: 'keyword-fallback' });
       }
     }
 
-    return results.sort((a, b) => b.score - a.score).slice(0, 10);
+    return results
+      .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
+      .slice(0, limit);
   }
 
   async suggestMCPs(requirements) {

--- a/lib/router/retriever.js
+++ b/lib/router/retriever.js
@@ -1,0 +1,131 @@
+const DEFAULT_TOP_K = 10;
+
+class VectorStoreUnavailableError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'VectorStoreUnavailableError';
+  }
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function resolveFetch(fetchImpl) {
+  if (fetchImpl) {
+    return fetchImpl;
+  }
+
+  if (typeof globalThis.fetch === 'function') {
+    return globalThis.fetch.bind(globalThis);
+  }
+
+  throw new Error('A fetch implementation is required to use MCPVectorRetriever');
+}
+
+export class MCPVectorRetriever {
+  constructor(options = {}) {
+    const {
+      endpoint = process.env.MCP_VECTOR_DB_URL,
+      topK = process.env.MCP_VECTOR_DB_TOP_K,
+      fetchImpl
+    } = options;
+
+    this.endpoint = endpoint;
+    const parsedTopK = Number.parseInt(topK, 10);
+    this.topK = Number.isFinite(parsedTopK) && parsedTopK > 0 ? parsedTopK : DEFAULT_TOP_K;
+    this.fetch = resolveFetch(fetchImpl);
+  }
+
+  isEnabled() {
+    return Boolean(this.endpoint);
+  }
+
+  async retrieve(query, options = {}) {
+    if (!query || !query.trim()) {
+      return [];
+    }
+
+    if (!this.isEnabled()) {
+      throw new VectorStoreUnavailableError('Vector store endpoint not configured');
+    }
+
+    const limit = Number.isFinite(options.topK) && options.topK > 0 ? options.topK : this.topK;
+    const payload = {
+      query,
+      topK: limit
+    };
+
+    let response;
+    try {
+      response = await this.fetch(this.endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+    } catch (error) {
+      throw new VectorStoreUnavailableError(`Failed to reach vector store: ${error.message}`);
+    }
+
+    if (!response.ok) {
+      let details = '';
+      try {
+        details = await response.text();
+      } catch (error) {
+        details = error.message;
+      }
+      const statusLine = `${response.status} ${response.statusText}`.trim();
+      const suffix = details ? ` - ${details}` : '';
+      throw new VectorStoreUnavailableError(`Vector store responded with ${statusLine}${suffix}`);
+    }
+
+    let data;
+    try {
+      data = await response.json();
+    } catch (error) {
+      throw new VectorStoreUnavailableError(`Vector store returned invalid JSON: ${error.message}`);
+    }
+
+    const rawResults = Array.isArray(data.results)
+      ? data.results
+      : Array.isArray(data.matches)
+        ? data.matches
+        : [];
+
+    return rawResults.slice(0, limit).map((match, index) => this.mapResult(match, index));
+  }
+
+  mapResult(match, index) {
+    const metadata = isPlainObject(match.metadata) ? match.metadata : {};
+    const name = match.name ?? metadata.name ?? match.id ?? `mcp-${index}`;
+    const description = match.description ?? metadata.description ?? '';
+
+    const scoreCandidates = [
+      match.score,
+      match.similarity,
+      match.relevance,
+      metadata.score,
+      metadata.similarity,
+      metadata.relevance
+    ];
+
+    const relevance = scoreCandidates.find(value => typeof value === 'number' && Number.isFinite(value)) ?? 0;
+
+    const result = {
+      id: match.id ?? metadata.id ?? name,
+      name,
+      description,
+      relevance,
+      score: relevance,
+      source: match.source ?? metadata.source ?? 'vector'
+    };
+
+    if (metadata && Object.keys(metadata).length > 0) {
+      result.metadata = metadata;
+    }
+
+    return result;
+  }
+}
+
+export { VectorStoreUnavailableError };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "claude-mcp": "./bin/wtf-mcp.js"
   },
   "scripts": {
-    "test": "node test/test-mcp-server.js",
+    "test": "node test/test-mcp-server.js && node test/retriever.test.js",
     "lint": "eslint lib/",
     "prepare": "npm run build",
     "build": "echo 'Build complete'",

--- a/test/retriever.test.js
+++ b/test/retriever.test.js
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+
+import assert from 'assert';
+import http from 'http';
+import { MCPVectorRetriever, VectorStoreUnavailableError } from '../lib/router/retriever.js';
+
+const SAMPLE_MCP_RECORDS = {
+  database: [
+    {
+      id: 'sql-master',
+      name: 'SQL Master',
+      description: 'Helps with SQL schema design and query optimization',
+      score: 0.91,
+      metadata: { categories: ['database', 'sql'] }
+    },
+    {
+      id: 'data-auditor',
+      name: 'Data Auditor',
+      description: 'Reviews data pipelines for reliability',
+      score: 0.78,
+      metadata: { categories: ['data'] }
+    },
+    {
+      id: 'general-helper',
+      name: 'General Helper',
+      description: 'Provides broad project assistance',
+      score: 0.55,
+      metadata: { categories: ['general'] }
+    }
+  ],
+  api: [
+    {
+      id: 'rest-navigator',
+      name: 'REST Navigator',
+      description: 'Guides REST API design and integration',
+      score: 0.89,
+      metadata: { categories: ['api', 'rest'] }
+    },
+    {
+      id: 'http-tester',
+      name: 'HTTP Tester',
+      description: 'Validates API endpoints and payloads',
+      score: 0.75,
+      metadata: { categories: ['api'] }
+    }
+  ]
+};
+
+function createMockVectorStore() {
+  const server = http.createServer((req, res) => {
+    if (req.method !== 'POST') {
+      res.writeHead(405);
+      return res.end();
+    }
+
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', () => {
+      let query = '';
+      try {
+        const payload = JSON.parse(body || '{}');
+        query = payload.query || '';
+      } catch (error) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        return res.end(JSON.stringify({ error: error.message }));
+      }
+
+      const lowerQuery = query.toLowerCase();
+      let results = SAMPLE_MCP_RECORDS.database;
+
+      if (/(api|rest|endpoint|integration)/i.test(lowerQuery)) {
+        results = SAMPLE_MCP_RECORDS.api;
+      } else if (/(database|sql|schema|postgres)/i.test(lowerQuery)) {
+        results = SAMPLE_MCP_RECORDS.database;
+      }
+
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ results }));
+    });
+  });
+
+  return new Promise(resolve => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({
+        url: `http://127.0.0.1:${port}/query`,
+        close: () => new Promise(res => server.close(res))
+      });
+    });
+  });
+}
+
+async function run() {
+  console.log('\n🧪 Testing MCP vector retriever');
+  const mockServer = await createMockVectorStore();
+
+  try {
+    const retriever = new MCPVectorRetriever({
+      endpoint: mockServer.url,
+      topK: 3
+    });
+
+    const databaseResults = await retriever.retrieve('Need help designing a SQL database schema');
+    assert.strictEqual(databaseResults.length, 3, 'Expected three results for database query');
+    assert.strictEqual(databaseResults[0].name, 'SQL Master');
+    assert.ok(databaseResults[0].relevance >= databaseResults[1].relevance);
+
+    const apiResults = await retriever.retrieve('How do I integrate a REST endpoint?');
+    assert.strictEqual(apiResults[0].name, 'REST Navigator');
+    assert.ok(apiResults[0].relevance >= apiResults[apiResults.length - 1].relevance);
+
+    const limitedResults = await retriever.retrieve('database migrations', { topK: 2 });
+    assert.strictEqual(limitedResults.length, 2, 'Should respect topK override');
+
+    let unavailableErrorCaught = false;
+    const offlineRetriever = new MCPVectorRetriever({ endpoint: null, fetchImpl: retriever.fetch });
+    try {
+      await offlineRetriever.retrieve('anything');
+    } catch (error) {
+      unavailableErrorCaught = error instanceof VectorStoreUnavailableError;
+    }
+    assert.ok(unavailableErrorCaught, 'Should throw VectorStoreUnavailableError when misconfigured');
+
+    console.log('✅ MCP vector retriever integration tests passed');
+  } finally {
+    await mockServer.close();
+  }
+}
+
+run().catch(error => {
+  console.error('❌ MCP vector retriever tests failed');
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add an MCP vector retriever that queries the configured vector store and normalizes the results
- update MCP search to prefer vector retrieval with a keyword-based fallback when the store is unavailable
- add integration coverage for the retriever and run it as part of the npm test suite

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e17dc163f48326b3227e62b2230139