### PR TITLE
feat: add vector store ingestion pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,11 +258,38 @@ npx wtf-mcp-manager init                # Initialize project
 npx wtf-mcp-manager list                # Show all MCPs
 npx wtf-mcp-manager enable supabase     # Enable specific MCP
 npx wtf-mcp-manager detect              # Auto-detect MCPs
+npx wtf-mcp-manager ingest              # Ingest metadata into your vector store
 npx wtf-mcp-manager doctor              # Diagnose issues
 
 # Interactive mode
 npx wtf-mcp-manager
 ```
+
+### Vector Store Ingestion & Embeddings
+
+Use the `ingest` command to collect all MCP metadata from the built-in registry, discovery modules, and tool definitions, then persist it to your vector database for semantic search.
+
+```bash
+# Dry run – view a preview without writing
+npx wtf-mcp-manager ingest --dry-run
+
+# Full ingestion (requires environment variables below)
+npx wtf-mcp-manager ingest
+```
+
+Set the required credentials in `.claude/.env` (loaded automatically when the CLI runs):
+
+| Variable | Description |
+|----------|-------------|
+| `VECTOR_DB_PROVIDER` | Vector database provider (currently `chroma` is supported). |
+| `VECTOR_DB_URL` | Base URL for the vector database REST API. |
+| `VECTOR_DB_COLLECTION` | Collection/table name for MCP metadata (defaults to `wtf-mcps`). |
+| `VECTOR_DB_API_KEY` | API key or bearer token for the vector database (optional). |
+| `EMBEDDING_PROVIDER` | Embedding provider identifier (supports `anthropic`). |
+| `ANTHROPIC_API_KEY` | API key used to request embeddings from Anthropic. |
+| `ANTHROPIC_EMBEDDING_MODEL` | Override the Anthropic embedding model (defaults to `text-embedding-001`). |
+
+> 💡 These settings live beside your project configuration in `.claude/.env`, keeping secrets out of version control while letting the CLI bootstrap new MCP metadata automatically.
 
 ### Integration with Claude
 ```bash

--- a/bin/wtf-mcp.js
+++ b/bin/wtf-mcp.js
@@ -9,12 +9,15 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import ora from 'ora';
 import inquirer from 'inquirer';
+import dotenv from 'dotenv';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import fs from 'fs/promises';
+import { existsSync } from 'fs';
 import { MCPManager } from '../lib/manager.js';
 import { MCPRegistry } from '../lib/registry.js';
 import { AutoDetector } from '../lib/detector.js';
+import { collectMCPMetadata, ingestToVectorStore } from '../lib/router/vector-store.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -22,6 +25,15 @@ const packageJson = JSON.parse(await fs.readFile(join(__dirname, '..', 'package.
 
 const program = new Command();
 const manager = new MCPManager();
+
+function loadClaudeEnv() {
+  const claudeEnvPath = join(process.cwd(), '.claude', '.env');
+  if (existsSync(claudeEnvPath)) {
+    dotenv.config({ path: claudeEnvPath });
+  }
+}
+
+loadClaudeEnv();
 
 // Banner
 function showBanner() {
@@ -304,9 +316,9 @@ program
   .description('WTF is wrong? (Check configuration)')
   .action(async () => {
     console.log(chalk.cyan('\n🏥 Running diagnostics... WTF is going on?\n'));
-    
+
     const issues = await manager.diagnose();
-    
+
     if (issues.length === 0) {
       console.log(chalk.green('✅ Everything is fucking perfect!'));
     } else {
@@ -317,6 +329,45 @@ program
           console.log(chalk.gray(`    Fix: ${issue.fix}`));
         }
       });
+    }
+  });
+
+program
+  .command('ingest')
+  .description('Aggregate MCP metadata and push it into the configured vector store')
+  .option('--dry-run', 'Collect metadata and show a preview without writing to the vector store', false)
+  .action(async (options) => {
+    showBanner();
+    const spinner = ora('Collecting MCP metadata...').start();
+    let ingestSpinner;
+
+    try {
+      const records = await collectMCPMetadata();
+      spinner.succeed(chalk.green(`Collected ${records.length} MCP metadata records.`));
+
+      if (options.dryRun) {
+        console.log(chalk.cyan('\n🧪 Dry run preview (first 3 records):\n'));
+        records.slice(0, 3).forEach(record => {
+          console.log(chalk.yellow(`• ${record.name}`));
+          console.log(chalk.gray(`  Source: ${record.source}`));
+          if (record.description) {
+            console.log(chalk.gray(`  Description: ${record.description}`));
+          }
+          console.log('');
+        });
+        return;
+      }
+
+      ingestSpinner = ora('Writing embeddings to the vector store...').start();
+      const result = await ingestToVectorStore();
+      ingestSpinner.succeed(chalk.green(`Ingested ${result.count} records into ${result.provider} (${result.collection}).`));
+    } catch (error) {
+      if (ingestSpinner) {
+        ingestSpinner.fail(chalk.red(`Failed to write to vector store: ${error.message}`));
+      } else {
+        spinner.fail(chalk.red(`Failed to ingest metadata: ${error.message}`));
+      }
+      process.exit(1);
     }
   });
 

--- a/lib/router/vector-store.js
+++ b/lib/router/vector-store.js
@@ -1,0 +1,356 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import fetch from 'node-fetch';
+import { MCPRegistry } from '../registry.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+
+function coerceExamples(examples) {
+  if (!examples) {
+    return [];
+  }
+
+  if (Array.isArray(examples)) {
+    return examples.map(example => {
+      if (typeof example === 'string') {
+        return example;
+      }
+      return JSON.stringify(example);
+    });
+  }
+
+  return [typeof examples === 'string' ? examples : JSON.stringify(examples)];
+}
+
+export function normalizeMetadata(entry) {
+  if (!entry || !entry.id) {
+    throw new Error('Metadata entry must include an id');
+  }
+
+  return {
+    id: String(entry.id),
+    name: entry.name ? String(entry.name) : entry.id,
+    description: entry.description ? String(entry.description) : '',
+    schema: entry.schema ?? null,
+    examples: coerceExamples(entry.examples),
+    source: entry.source || 'unknown',
+    metadata: entry.metadata || {}
+  };
+}
+
+export function createDocument(entry) {
+  const parts = [
+    `Name: ${entry.name}`,
+    entry.description ? `Description: ${entry.description}` : null,
+    entry.schema ? `Schema: ${JSON.stringify(entry.schema, null, 2)}` : null,
+    entry.examples?.length ? `Examples:\n${entry.examples.join('\n')}` : null,
+    entry.metadata && Object.keys(entry.metadata).length
+      ? `Metadata: ${JSON.stringify(entry.metadata, null, 2)}`
+      : null,
+    `Source: ${entry.source}`
+  ];
+
+  return parts.filter(Boolean).join('\n\n');
+}
+
+export function toVectorRecord(entry) {
+  const normalized = normalizeMetadata(entry);
+  return {
+    ...normalized,
+    document: createDocument(normalized)
+  };
+}
+
+async function collectRegistryMetadata() {
+  const registry = new MCPRegistry();
+  const all = registry.getAll();
+  return Object.entries(all).map(([id, info]) => ({
+    id: `registry:${id}`,
+    name: info.name || id,
+    description: info.description || '',
+    schema: {
+      package: info.package,
+      command: info.command,
+      args: info.args,
+      requiredEnv: info.requiredEnv || []
+    },
+    examples: [],
+    source: 'registry',
+    metadata: {
+      categories: info.categories || [],
+      autoDetect: info.autoDetect || []
+    }
+  }));
+}
+
+async function collectToolMetadata(rootDir = PROJECT_ROOT) {
+  const file = path.join(rootDir, 'mcp-tools.json');
+  const content = await fs.readFile(file, 'utf8');
+  const parsed = JSON.parse(content);
+  const tools = (parsed.tools || []).map(tool => ({
+    id: `tool:${tool.name}`,
+    name: tool.name,
+    description: tool.description || '',
+    schema: tool.inputSchema || null,
+    examples: [],
+    source: 'tool',
+    metadata: { type: 'mcp-tool' }
+  }));
+
+  const examples = parsed.examples?.map((example, index) => ({
+    id: `tool-example:${index}`,
+    name: example.user || `example-${index}`,
+    description: example.assistant || '',
+    schema: example.tool_calls || null,
+    examples: [],
+    source: 'tool-example',
+    metadata: { type: 'conversation-example' }
+  })) || [];
+
+  return [...tools, ...examples];
+}
+
+function extractRecordsFromObject(obj, source) {
+  if (!obj || typeof obj !== 'object') {
+    return [];
+  }
+
+  if (Array.isArray(obj)) {
+    return obj
+      .filter(item => item && typeof item === 'object')
+      .map((item, index) => ({
+        id: `${source}:${index}`,
+        name: item.name || `${source}-${index}`,
+        description: item.description || '',
+        schema: item.parameters || item.schema || null,
+        examples: item.examples || [],
+        source,
+        metadata: { ...item }
+      }));
+  }
+
+  return Object.entries(obj)
+    .filter(([, value]) => value && typeof value === 'object')
+    .map(([key, value]) => ({
+      id: `${source}:${key}`,
+      name: value.name || key,
+      description: value.description || '',
+      schema: value.parameters || value.schema || value.endpoints || null,
+      examples: value.examples || [],
+      source,
+      metadata: { ...value }
+    }));
+}
+
+async function collectDiscoveryMetadata() {
+  const discoveryDir = path.join(__dirname, '..', 'discovery');
+  const files = await fs.readdir(discoveryDir);
+  const entries = [];
+
+  for (const file of files) {
+    if (!file.endsWith('.js')) continue;
+    const modulePath = path.join(discoveryDir, file);
+    const mod = await import(pathToFileURL(modulePath).href);
+    const exportEntries = Object.entries(mod)
+      .filter(([, value]) => typeof value === 'object' && value !== null);
+
+    for (const [exportName, value] of exportEntries) {
+      const source = `discovery:${path.basename(file, '.js')}:${exportName}`;
+      entries.push(...extractRecordsFromObject(value, source));
+    }
+  }
+
+  return entries;
+}
+
+export async function collectMCPMetadata(options = {}) {
+  const rootDir = options.rootDir || PROJECT_ROOT;
+  const [registry, tools, discovery] = await Promise.all([
+    collectRegistryMetadata(),
+    collectToolMetadata(rootDir),
+    collectDiscoveryMetadata()
+  ]);
+
+  return [...registry, ...tools, ...discovery];
+}
+
+export async function generateEmbeddings(records, embeddingProvider) {
+  if (!embeddingProvider || typeof embeddingProvider.embed !== 'function') {
+    throw new Error('embeddingProvider must implement an embed(text, metadata) method');
+  }
+
+  const results = [];
+
+  for (const record of records) {
+    const embedding = await embeddingProvider.embed(record.document, record);
+    if (!Array.isArray(embedding)) {
+      throw new Error('Embedding provider must return an array of numbers');
+    }
+    results.push({ ...record, embedding });
+  }
+
+  return results;
+}
+
+export class AnthropicEmbeddingProvider {
+  constructor({ apiKey, model = 'text-embedding-001', fetchImpl = fetch } = {}) {
+    if (!apiKey) {
+      throw new Error('Anthropic API key is required for embeddings');
+    }
+    this.apiKey = apiKey;
+    this.model = model;
+    this.fetch = fetchImpl;
+  }
+
+  async embed(text) {
+    const response = await this.fetch('https://api.anthropic.com/v1/embeddings', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': this.apiKey,
+        'anthropic-version': '2023-06-01'
+      },
+      body: JSON.stringify({
+        model: this.model,
+        input: text
+      })
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Anthropic embedding request failed: ${response.status} ${errorText}`);
+    }
+
+    const data = await response.json();
+    return data.embedding;
+  }
+}
+
+export function createEmbeddingProviderFromEnv(options = {}) {
+  const provider = options.provider || process.env.EMBEDDING_PROVIDER || 'anthropic';
+
+  if (provider === 'anthropic') {
+    const apiKey = options.apiKey || process.env.ANTHROPIC_API_KEY;
+    const model = options.model || process.env.ANTHROPIC_EMBEDDING_MODEL;
+    return new AnthropicEmbeddingProvider({ apiKey, model, fetchImpl: options.fetch });
+  }
+
+  throw new Error(`Unsupported embedding provider: ${provider}`);
+}
+
+export function getVectorStoreConfigFromEnv(env = process.env) {
+  const provider = env.VECTOR_DB_PROVIDER || 'chroma';
+  const url = env.VECTOR_DB_URL;
+  const collection = env.VECTOR_DB_COLLECTION || 'wtf-mcps';
+  const apiKey = env.VECTOR_DB_API_KEY;
+
+  if (!url) {
+    throw new Error('VECTOR_DB_URL environment variable is required');
+  }
+
+  return { provider, url, collection, apiKey };
+}
+
+export class VectorStoreClient {
+  constructor(config, fetchImpl = fetch) {
+    if (!config || !config.provider) {
+      throw new Error('Vector store configuration must include provider');
+    }
+    this.config = config;
+    this.fetch = fetchImpl;
+  }
+
+  async ensureCollection() {
+    if (this.config.provider !== 'chroma') {
+      throw new Error(`Unsupported vector store provider: ${this.config.provider}`);
+    }
+
+    const response = await this.fetch(`${this.config.url}/collections`, {
+      method: 'POST',
+      headers: this.buildHeaders(),
+      body: JSON.stringify({ name: this.config.collection })
+    });
+
+    if (!response.ok && response.status !== 409) {
+      const text = await response.text();
+      throw new Error(`Failed to ensure collection: ${response.status} ${text}`);
+    }
+  }
+
+  buildHeaders() {
+    const headers = { 'Content-Type': 'application/json' };
+    if (this.config.apiKey) {
+      headers['Authorization'] = `Bearer ${this.config.apiKey}`;
+    }
+    return headers;
+  }
+
+  async upsert(records) {
+    if (this.config.provider !== 'chroma') {
+      throw new Error(`Unsupported vector store provider: ${this.config.provider}`);
+    }
+
+    if (!Array.isArray(records) || records.length === 0) {
+      return;
+    }
+
+    const payload = {
+      ids: records.map(record => record.id),
+      embeddings: records.map(record => record.embedding),
+      documents: records.map(record => record.document),
+      metadatas: records.map(record => ({
+        name: record.name,
+        description: record.description,
+        source: record.source,
+        schema: record.schema,
+        examples: record.examples,
+        metadata: record.metadata
+      }))
+    };
+
+    const response = await this.fetch(`${this.config.url}/collections/${encodeURIComponent(this.config.collection)}/upsert`, {
+      method: 'POST',
+      headers: this.buildHeaders(),
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Failed to upsert records: ${response.status} ${text}`);
+    }
+  }
+}
+
+export async function ingestToVectorStore(options = {}) {
+  const records = await collectMCPMetadata({ rootDir: options.rootDir });
+  const vectorRecords = records.map(toVectorRecord);
+  const embeddingProvider = options.embeddingProvider || createEmbeddingProviderFromEnv({
+    provider: options.embeddingProviderName,
+    apiKey: options.embeddingApiKey,
+    model: options.embeddingModel,
+    fetch: options.fetch
+  });
+  const embedded = await generateEmbeddings(vectorRecords, embeddingProvider);
+  const vectorStoreConfig = options.vectorStoreConfig || getVectorStoreConfigFromEnv();
+  const vectorStore = options.vectorStore || new VectorStoreClient(vectorStoreConfig, options.fetch);
+
+  await vectorStore.ensureCollection();
+  await vectorStore.upsert(embedded);
+
+  return {
+    count: embedded.length,
+    provider: vectorStoreConfig.provider,
+    collection: vectorStoreConfig.collection
+  };
+}
+
+export default {
+  collectMCPMetadata,
+  ingestToVectorStore,
+  VectorStoreClient,
+  createEmbeddingProviderFromEnv,
+  getVectorStoreConfigFromEnv
+};

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "claude-mcp": "./bin/wtf-mcp.js"
   },
   "scripts": {
-    "test": "node test/test-mcp-server.js",
+    "test": "node test/test-mcp-server.js && node test/test-ingestion.js",
     "lint": "eslint lib/",
     "prepare": "npm run build",
     "build": "echo 'Build complete'",

--- a/test/test-ingestion.js
+++ b/test/test-ingestion.js
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+
+import assert from 'assert';
+import chalk from 'chalk';
+import {
+  collectMCPMetadata,
+  toVectorRecord,
+  ingestToVectorStore,
+  VectorStoreClient
+} from '../lib/router/vector-store.js';
+
+class MockEmbedder {
+  constructor() {
+    this.calls = [];
+  }
+
+  async embed(text, record) {
+    this.calls.push({ text, record });
+    return [text.length % 10, record.id.length];
+  }
+}
+
+class MockVectorStore {
+  constructor() {
+    this.collectionEnsured = false;
+    this.upsertRecords = [];
+  }
+
+  async ensureCollection() {
+    this.collectionEnsured = true;
+  }
+
+  async upsert(records) {
+    this.upsertRecords.push(...records);
+  }
+}
+
+async function testMetadataCollection() {
+  const records = await collectMCPMetadata();
+  assert(records.length > 0, 'Expected to collect at least one metadata record');
+  const vectorRecord = toVectorRecord(records[0]);
+  assert(vectorRecord.document.includes('Name:'), 'Vector record should contain a document payload');
+  console.log(chalk.green(`✅ Collected ${records.length} metadata records`));
+}
+
+async function testVectorStoreClient() {
+  const requests = [];
+  const mockFetch = async (url, init = {}) => {
+    requests.push({ url, init });
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+      text: async () => ''
+    };
+  };
+
+  const client = new VectorStoreClient({
+    provider: 'chroma',
+    url: 'https://vector.example.com',
+    collection: 'wtf-test'
+  }, mockFetch);
+
+  await client.ensureCollection();
+  const ensureRequest = requests.find(req => req.url.endsWith('/collections'));
+  assert(ensureRequest, 'Expected ensureCollection to hit /collections endpoint');
+
+  await client.upsert([
+    {
+      id: 'registry:test',
+      name: 'Test',
+      description: 'Desc',
+      source: 'registry',
+      schema: null,
+      examples: [],
+      metadata: {},
+      document: 'doc',
+      embedding: [0.1, 0.2]
+    }
+  ]);
+
+  const upsertRequest = requests.find(req => req.url.includes('/collections/wtf-test/upsert'));
+  assert(upsertRequest, 'Expected upsert to call the collection upsert endpoint');
+  const payload = JSON.parse(upsertRequest.init.body);
+  assert.strictEqual(payload.ids[0], 'registry:test');
+  assert.deepStrictEqual(payload.embeddings[0], [0.1, 0.2]);
+  console.log(chalk.green('✅ VectorStoreClient ensures collection and upserts records'));
+}
+
+async function testIngestionPipeline() {
+  const embedder = new MockEmbedder();
+  const store = new MockVectorStore();
+  const result = await ingestToVectorStore({
+    embeddingProvider: embedder,
+    vectorStore: store,
+    vectorStoreConfig: {
+      provider: 'chroma',
+      url: 'https://vector.example.com',
+      collection: 'wtf-test'
+    }
+  });
+
+  assert(store.collectionEnsured, 'Expected vector store collection to be ensured');
+  assert(store.upsertRecords.length > 0, 'Expected records to be written to the vector store');
+  assert.strictEqual(result.collection, 'wtf-test');
+  assert.strictEqual(result.provider, 'chroma');
+  assert(embedder.calls.length > 0, 'Embedding provider should be invoked');
+  console.log(chalk.green(`✅ Ingestion pipeline wrote ${store.upsertRecords.length} records`));
+}
+
+async function run() {
+  console.log(chalk.cyan('\n🧪 Testing ingestion pipeline\n'));
+  await testMetadataCollection();
+  await testVectorStoreClient();
+  await testIngestionPipeline();
+  console.log(chalk.cyan('\n🎯 Ingestion tests complete!\n'));
+}
+
+run().catch(error => {
+  console.error(chalk.red('❌ Ingestion tests failed:'), error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a router vector-store module that normalizes registry, tool, and discovery metadata before embedding and storing in a Chroma collection
- load `.claude/.env`, expose an `ingest` CLI with dry-run preview, and document required vector/embedding environment variables
- cover ingestion and vector client behaviors with unit tests and update the npm test script

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e17cd630108326a7951c48ecf20f1f