### PR TITLE
feat: add MCP router ingestion and retrieval

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,44 @@ Main commands accessible via `npx wtf-mcp-manager` or aliases `wtf-mcp`, `claude
 - `global <list|disable> [mcp]` - Manage global Claude MCPs
 - `doctor` - Diagnose configuration issues
 - `interactive` - Interactive mode with menu
+- `wtf-mcp-router ingest` - Normalize metadata and upsert embeddings into the router vector store
+- `wtf-mcp-router retrieve <query>` - Debug semantic routing responses locally
+
+### Router configuration quick reference
+
+- **Vector store selection**: `ROUTER_VECTOR_STORE` supports `memory` (default), `supabase`, `qdrant`, and `chroma`. Provide connection parameters via `ROUTER_VECTOR_STORE_URL` / `ROUTER_VECTOR_STORE_API_KEY`, or Supabase/Qdrant/Chroma specific variables (`ROUTER_SUPABASE_TABLE`, `ROUTER_QDRANT_COLLECTION`, `ROUTER_CHROMA_COLLECTION`, etc.).
+- **Embeddings**: Set `ROUTER_EMBEDDING_PROVIDER` to `openai`, `anthropic`, or `local`. Supply credentials (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`) and optional overrides (`ROUTER_EMBEDDING_MODEL`, `ROUTER_EMBEDDING_ENDPOINT`).
+- **Metadata sources**: Add remote registries with `ROUTER_REMOTE_REGISTRIES`, load custom JSON/YAML via `ROUTER_ADDITIONAL_GLOBS`, and point at generated MCP manifests with `ROUTER_DYNAMIC_CONFIG_DIR`.
+- **Performance**: Tweak `ROUTER_TOP_K`, `ROUTER_CACHE_TTL_MS`, `ROUTER_MEMORY_STORE_PATH`, and enable auto-ingestion on boot using `ROUTER_AUTO_INGEST=true`.
+- **Observability**: Enable router telemetry with `ROUTER_OBSERVABILITY_ENABLED=true` (defaults to console JSON payloads, configurable via `ROUTER_OBSERVABILITY_EMITTER`).
+
+> Optional packages: install the clients you need per backend (`npm install openai`, `npm install @supabase/supabase-js`, `npm install @qdrant/js-client-rest`, `npm install chromadb`).
+
+### Local Docker Compose profiles
+
+For local experimentation, spin up vector stores quickly:
+
+```yaml
+# docker-compose.router.yml
+services:
+  qdrant:
+    image: qdrant/qdrant:latest
+    ports:
+      - "6333:6333"
+  chroma:
+    image: chromadb/chroma:latest
+    ports:
+      - "8000:8000"
+```
+
+Point the router at the desired service:
+
+```bash
+ROUTER_VECTOR_STORE=qdrant \
+ROUTER_VECTOR_STORE_URL=http://localhost:6333 \
+ROUTER_QDRANT_COLLECTION=mcp-router \
+npx wtf-mcp-router ingest
+```
 
 ## MCP Server Protocol
 

--- a/README.md
+++ b/README.md
@@ -273,6 +273,80 @@ npx wtf-mcp-manager serve
 # Then control MCPs directly in Claude!
 ```
 
+### Semantic Router & Retrieval
+
+The router module keeps a normalized catalogue of MCP metadata, embeds it, and serves fast semantic retrieval for Claude. Run the dedicated CLI to keep the vector store fresh:
+
+```bash
+# Normalize metadata from the registry, local configs, and custom files
+npx wtf-mcp-router ingest
+
+# Debug a query against the vector DB
+npx wtf-mcp-router retrieve "I need a database API"
+```
+
+#### Configuration cheat sheet
+
+| Variable | Description |
+| --- | --- |
+| `ROUTER_VECTOR_STORE` | `memory` (default), `supabase`, `qdrant`, or `chroma`. |
+| `ROUTER_VECTOR_STORE_URL` / `ROUTER_VECTOR_STORE_API_KEY` | Connection details for remote stores. |
+| `ROUTER_SUPABASE_TABLE` / `ROUTER_SUPABASE_SCHEMA` / `ROUTER_SUPABASE_MATCH_FN` | Supabase table + RPC function for pgvector search. |
+| `ROUTER_QDRANT_COLLECTION` / `ROUTER_QDRANT_TIMEOUT_MS` | Target collection + timeout. |
+| `ROUTER_CHROMA_COLLECTION` / `ROUTER_CHROMA_TENANT` / `ROUTER_CHROMA_DATABASE` | Chroma namespace configuration. |
+| `ROUTER_EMBEDDING_PROVIDER` | `openai`, `anthropic`, or `local` (hash-based fallback). |
+| `ROUTER_EMBEDDING_MODEL` / `ROUTER_EMBEDDING_ENDPOINT` | Override provider defaults. |
+| `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` | Credentials for embedding providers. |
+| `ROUTER_REMOTE_REGISTRIES` | Comma-separated registry URLs to ingest (JSON/YAML). |
+| `ROUTER_ADDITIONAL_GLOBS` | Glob patterns for local JSON/YAML MCP definitions. |
+| `ROUTER_DYNAMIC_CONFIG_DIR` | Relative directory that contains generated MCP manifests (`.claude` by default). |
+| `ROUTER_TOP_K` | Default number of matches returned by the retriever. |
+| `ROUTER_CACHE_TTL_MS` | Cache lifetime for repeated lookups. |
+| `ROUTER_MEMORY_STORE_PATH` | On-disk cache file when using the built-in memory vector store. |
+| `ROUTER_AUTO_INGEST` | Set to `true` to ingest automatically when the MCP server boots. |
+| `ROUTER_OBSERVABILITY_ENABLED` / `ROUTER_OBSERVABILITY_EMITTER` | Emit router latency + count metrics (defaults to console JSON). |
+
+> ⚠️ Vector store clients are optional dependencies. Install the ones you need, e.g. `npm install openai`, `npm install @supabase/supabase-js`, `npm install @qdrant/js-client-rest`, or `npm install chromadb`.
+
+#### Local Docker Compose profiles
+
+Quick-start infrastructure for local retrieval experiments:
+
+```yaml
+# docker-compose.router.yml
+services:
+  qdrant:
+    image: qdrant/qdrant:latest
+    ports:
+      - "6333:6333"
+    environment:
+      QDRANT__SERVICE__GRPC_PORT: 6334
+  chroma:
+    image: chromadb/chroma:latest
+    ports:
+      - "8000:8000"
+```
+
+Point the router at one of the services:
+
+```bash
+ROUTER_VECTOR_STORE=qdrant \
+ROUTER_VECTOR_STORE_URL=http://localhost:6333 \
+ROUTER_QDRANT_COLLECTION=mcp-router \
+npx wtf-mcp-router ingest
+```
+
+#### Observability hooks
+
+Enable lightweight JSON metrics during ingestion and retrieval by setting:
+
+```bash
+export ROUTER_OBSERVABILITY_ENABLED=true
+export ROUTER_OBSERVABILITY_EMITTER=console
+```
+
+The MCP server will log per-query latency and hit counts, which can be piped to your tracing or token-tracking pipeline.
+
 ---
 
 ## 🚨 Troubleshooting

--- a/bin/wtf-mcp-router.js
+++ b/bin/wtf-mcp-router.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+import { Command } from 'commander';
+import dotenv from 'dotenv';
+import { MCPRouterService, RouterConfig } from '../lib/router/index.js';
+
+dotenv.config();
+
+const program = new Command();
+program
+  .name('wtf-mcp-router')
+  .description('Metadata router utilities for MCP Manager');
+
+program
+  .command('ingest')
+  .description('Normalize MCP metadata and upsert embeddings into the configured vector store')
+  .option('--skip-remote', 'Skip loading remote registries')
+  .option('--top-k <number>', 'Override top-k configuration during ingestion preview')
+  .action(async (options) => {
+    const config = new RouterConfig();
+    if (options.topK) {
+      config.defaultTopK = Number(options.topK);
+    }
+
+    if (options.skipRemote) {
+      config.remoteRegistries = [];
+    }
+
+    const service = new MCPRouterService({ config });
+
+    try {
+      const result = await service.ingest(options);
+      console.log(JSON.stringify({
+        status: 'ok',
+        vectorStore: config.vectorStore,
+        embeddingProvider: config.embeddingProvider,
+        count: result.count,
+        sources: result.sources
+      }, null, 2));
+      process.exit(0);
+    } catch (error) {
+      console.error('Router ingestion failed:', error.message);
+      process.exit(1);
+    }
+  });
+
+program
+  .command('retrieve <query>')
+  .description('Execute an ad-hoc retrieval against the router vector store for debugging')
+  .option('--top-k <number>', 'Number of matches to return')
+  .action(async (query, options) => {
+    const config = new RouterConfig();
+    if (options.topK) {
+      config.defaultTopK = Number(options.topK);
+    }
+
+    const service = new MCPRouterService({ config });
+
+    try {
+      const { results } = await service.retrieve(query, { topK: config.defaultTopK });
+      console.log(JSON.stringify({
+        status: 'ok',
+        count: results.length,
+        results
+      }, null, 2));
+      process.exit(0);
+    } catch (error) {
+      console.error('Router retrieval failed:', error.message);
+      process.exit(1);
+    }
+  });
+
+program.parseAsync(process.argv);

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,13 +2,23 @@
  * WTF-MCP-Manager Main Entry Point
  */
 
-export { MCPManager } from './manager.js';
-export { MCPRegistry } from './registry.js';
-export { AutoDetector } from './detector.js';
+import { MCPManager } from './manager.js';
+import { MCPRegistry } from './registry.js';
+import { AutoDetector } from './detector.js';
+import { MCPRouterService, RouterConfig, RouterIngestor, RouterRetriever } from './router/index.js';
+
+export { MCPManager };
+export { MCPRegistry };
+export { AutoDetector };
+export { MCPRouterService, RouterConfig, RouterIngestor, RouterRetriever };
 
 // Re-export for convenience
 export default {
   MCPManager,
   MCPRegistry,
-  AutoDetector
+  AutoDetector,
+  MCPRouterService,
+  RouterConfig,
+  RouterIngestor,
+  RouterRetriever
 };

--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -15,6 +15,7 @@ import { MCPRegistry } from './registry.js';
 import { AutoDetector } from './detector.js';
 import { DynamicMCPGenerator } from './dynamic/mcp-generator.js';
 import { APIDiscoveryService } from './discovery/api-discovery.js';
+import { MCPRouterService, RouterConfig } from './router/index.js';
 
 class WTFMCPManagerServer {
   constructor() {
@@ -23,6 +24,9 @@ class WTFMCPManagerServer {
     this.detector = new AutoDetector();
     this.generator = new DynamicMCPGenerator();
     this.discovery = new APIDiscoveryService();
+    this.router = new MCPRouterService({
+      config: new RouterConfig({ projectRoot: process.cwd() })
+    });
     this.availableMCPs = null;
     this.lastFetchTime = null;
     this.FETCH_CACHE_TTL = 30 * 60 * 1000; // 30 minutes
@@ -33,6 +37,8 @@ class WTFMCPManagerServer {
   async initialize() {
     await this.generator.init();
     console.error('🚀 Dynamic MCP Generator initialized');
+    await this.router.init();
+    console.error('🧭 MCP Router initialized');
   }
 
   /**
@@ -359,6 +365,9 @@ class WTFMCPManagerServer {
           const searchResults = await this.searchMCPs(params.query || '');
           return searchResults;
 
+        case 'route_tools':
+          return await this.routeTools(params);
+
         case 'diagnose':
           return await this.manager.diagnose();
 
@@ -452,6 +461,40 @@ class WTFMCPManagerServer {
     }
 
     return results.sort((a, b) => b.score - a.score).slice(0, 10);
+  }
+
+  async routeTools(params = {}) {
+    const query = (params.query || '').trim();
+    if (!query) {
+      throw new Error('query is required to route tools');
+    }
+
+    const topK = Number(params.topK || this.router.config.defaultTopK || 8);
+    const filter = params.filter;
+
+    const { results, cached, durationMs } = await this.router.retrieve(query, { topK, filter });
+    const tools = results.map((item) => ({
+      id: item.id,
+      name: item.name,
+      description: item.description,
+      source: item.source,
+      categories: item.categories,
+      tags: item.tags,
+      command: item.command,
+      args: item.args,
+      env: item.env,
+      sampleCalls: item.sampleCalls,
+      schema: item.schema
+    }));
+
+    return {
+      query,
+      topK,
+      cached,
+      count: tools.length,
+      tools,
+      durationMs
+    };
   }
 
   async suggestMCPs(requirements) {
@@ -942,6 +985,32 @@ async function runMCPServer() {
                         query: {
                           type: "string",
                           description: "Search query (e.g., 'database', 'web scraping', 'github')"
+                        }
+                      },
+                      required: ["query"],
+                      additionalProperties: false
+                    }
+                  },
+                  {
+                    name: "route_tools",
+                    description: "Retrieve the top matching MCP tool metadata using the embedding router",
+                    inputSchema: {
+                      type: "object",
+                      properties: {
+                        query: {
+                          type: "string",
+                          description: "Natural language request to match against available MCP tools"
+                        },
+                        topK: {
+                          type: "integer",
+                          description: "Maximum number of tools to return",
+                          minimum: 1,
+                          maximum: 20
+                        },
+                        filter: {
+                          type: "object",
+                          description: "Vector store specific metadata filter",
+                          additionalProperties: true
                         }
                       },
                       required: ["query"],

--- a/lib/router/cache.js
+++ b/lib/router/cache.js
@@ -1,0 +1,27 @@
+export class QueryCache {
+  constructor(ttlMs = 5 * 60 * 1000, maxEntries = 100) {
+    this.ttlMs = ttlMs;
+    this.maxEntries = maxEntries;
+    this.store = new Map();
+  }
+
+  get(key) {
+    const entry = this.store.get(key);
+    if (!entry) return null;
+    if (Date.now() > entry.expiresAt) {
+      this.store.delete(key);
+      return null;
+    }
+    return entry.value;
+  }
+
+  set(key, value) {
+    if (this.store.size >= this.maxEntries) {
+      const oldestKey = this.store.keys().next().value;
+      if (oldestKey) {
+        this.store.delete(oldestKey);
+      }
+    }
+    this.store.set(key, { value, expiresAt: Date.now() + this.ttlMs });
+  }
+}

--- a/lib/router/config.js
+++ b/lib/router/config.js
@@ -1,0 +1,52 @@
+export class RouterConfig {
+  constructor(overrides = {}) {
+    const env = process.env;
+
+    this.projectRoot = overrides.projectRoot || env.ROUTER_PROJECT_ROOT || process.cwd();
+    this.vectorStore = (overrides.vectorStore || env.ROUTER_VECTOR_STORE || 'memory').toLowerCase();
+    this.vectorStoreUrl = overrides.vectorStoreUrl || env.ROUTER_VECTOR_STORE_URL;
+    this.vectorStoreApiKey = overrides.vectorStoreApiKey || env.ROUTER_VECTOR_STORE_API_KEY;
+    this.supabase = {
+      table: overrides.supabase?.table || env.ROUTER_SUPABASE_TABLE || 'mcp_router_embeddings',
+      schema: overrides.supabase?.schema || env.ROUTER_SUPABASE_SCHEMA || 'public',
+      matchFn: overrides.supabase?.matchFn || env.ROUTER_SUPABASE_MATCH_FN || 'match_mcp_router'
+    };
+    this.qdrant = {
+      collection: overrides.qdrant?.collection || env.ROUTER_QDRANT_COLLECTION || 'mcp-router',
+      timeout: overrides.qdrant?.timeout || Number(env.ROUTER_QDRANT_TIMEOUT_MS || 20000)
+    };
+    this.chroma = {
+      collection: overrides.chroma?.collection || env.ROUTER_CHROMA_COLLECTION || 'mcp-router',
+      tenant: overrides.chroma?.tenant || env.ROUTER_CHROMA_TENANT,
+      database: overrides.chroma?.database || env.ROUTER_CHROMA_DATABASE
+    };
+
+    this.embeddingProvider = (overrides.embeddingProvider || env.ROUTER_EMBEDDING_PROVIDER || 'openai').toLowerCase();
+    this.embeddingModel = overrides.embeddingModel || env.ROUTER_EMBEDDING_MODEL;
+    this.embeddingApiKey = overrides.embeddingApiKey || env.ROUTER_EMBEDDING_API_KEY;
+    this.embeddingEndpoint = overrides.embeddingEndpoint || env.ROUTER_EMBEDDING_ENDPOINT;
+    this.embeddingDimension = Number(overrides.embeddingDimension || env.ROUTER_EMBEDDING_DIMENSION || 1536);
+
+    this.remoteRegistries = this.#parseList(overrides.remoteRegistries || env.ROUTER_REMOTE_REGISTRIES);
+    this.additionalGlobs = this.#parseList(overrides.additionalGlobs || env.ROUTER_ADDITIONAL_GLOBS);
+    this.dynamicConfigDir = overrides.dynamicConfigDir || env.ROUTER_DYNAMIC_CONFIG_DIR || '.claude';
+
+    this.defaultTopK = Number(overrides.defaultTopK || env.ROUTER_TOP_K || 8);
+    this.cacheTtlMs = Number(overrides.cacheTtlMs || env.ROUTER_CACHE_TTL_MS || 5 * 60 * 1000);
+    this.memoryStorePath = overrides.memoryStorePath || env.ROUTER_MEMORY_STORE_PATH || `${this.projectRoot}/.claude/router-index.json`;
+    this.observability = {
+      enabled: overrides.observability?.enabled ?? (env.ROUTER_OBSERVABILITY_ENABLED === 'true'),
+      emitter: overrides.observability?.emitter || env.ROUTER_OBSERVABILITY_EMITTER || 'console'
+    };
+    this.autoIngest = overrides.autoIngest ?? (env.ROUTER_AUTO_INGEST === 'true');
+  }
+
+  #parseList(value) {
+    if (!value) return [];
+    if (Array.isArray(value)) return value;
+    return value
+      .split(/[,\n]/)
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+}

--- a/lib/router/embeddings.js
+++ b/lib/router/embeddings.js
@@ -1,0 +1,125 @@
+import crypto from 'crypto';
+
+class BaseEmbeddingProvider {
+  constructor(config = {}) {
+    this.config = config;
+  }
+
+  async embed(texts) {
+    throw new Error('embed(texts) must be implemented by subclasses');
+  }
+}
+
+class OpenAIEmbeddingProvider extends BaseEmbeddingProvider {
+  async embed(texts) {
+    let OpenAIModule;
+    try {
+      OpenAIModule = await import('openai');
+    } catch (error) {
+      throw new Error('OpenAI client not installed. Install it with `npm install openai`.');
+    }
+    const { default: OpenAI } = OpenAIModule;
+    const apiKey = this.config.apiKey || process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      throw new Error('OpenAI API key is required for OpenAI embeddings');
+    }
+
+    const client = new OpenAI({ apiKey, baseURL: this.config.endpoint || process.env.OPENAI_BASE_URL });
+    const model = this.config.model || process.env.OPENAI_EMBEDDING_MODEL || 'text-embedding-3-small';
+
+    const response = await client.embeddings.create({
+      model,
+      input: texts
+    });
+
+    return response.data.map((item) => item.embedding);
+  }
+}
+
+class AnthropicEmbeddingProvider extends BaseEmbeddingProvider {
+  async embed(texts) {
+    const apiKey = this.config.apiKey || process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) {
+      throw new Error('Anthropic API key is required for Anthropics embeddings');
+    }
+
+    const model = this.config.model || process.env.ANTHROPIC_EMBEDDING_MODEL || 'claude-embedding-3-large';
+    const endpoint = this.config.endpoint || process.env.ANTHROPIC_EMBEDDING_ENDPOINT || 'https://api.anthropic.com/v1/embeddings';
+
+    const results = [];
+    for (const text of texts) {
+      let fetchFn = fetch;
+      if (typeof fetch === 'undefined') {
+        const { default: nodeFetch } = await import('node-fetch');
+        fetchFn = nodeFetch;
+      }
+      const response = await fetchFn(endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': apiKey,
+          'anthropic-version': '2023-06-01'
+        },
+        body: JSON.stringify({
+          model,
+          input: text
+        })
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Anthropic embedding error: ${response.status} ${errorText}`);
+      }
+
+      const payload = await response.json();
+      if (!payload.embedding) {
+        throw new Error('Anthropic response missing embedding field');
+      }
+
+      results.push(payload.embedding);
+    }
+
+    return results;
+  }
+}
+
+class LocalEmbeddingProvider extends BaseEmbeddingProvider {
+  constructor(config = {}) {
+    super(config);
+    this.dimension = Number(config.dimension || process.env.LOCAL_EMBEDDING_DIMENSION || 384);
+  }
+
+  async embed(texts) {
+    return texts.map((text) => this.#hashToVector(text));
+  }
+
+  #hashToVector(text) {
+    const vector = new Array(this.dimension).fill(0);
+    const tokens = text.toLowerCase().split(/\W+/).filter(Boolean);
+
+    for (const token of tokens) {
+      const hash = crypto.createHash('sha256').update(token).digest();
+      for (let i = 0; i < this.dimension; i++) {
+        vector[i] += hash[i % hash.length] / 255;
+      }
+    }
+
+    const magnitude = Math.sqrt(vector.reduce((sum, value) => sum + value * value, 0)) || 1;
+    return vector.map((value) => value / magnitude);
+  }
+}
+
+export class EmbeddingProviderFactory {
+  static async create(config = {}) {
+    switch (config.embeddingProvider) {
+      case 'openai':
+        return new OpenAIEmbeddingProvider(config);
+      case 'anthropic':
+        return new AnthropicEmbeddingProvider(config);
+      case 'local':
+        return new LocalEmbeddingProvider(config);
+      default:
+        throw new Error(`Unsupported embedding provider: ${config.embeddingProvider}`);
+    }
+  }
+}

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -1,0 +1,111 @@
+import { RouterConfig } from './config.js';
+import { MetadataNormalizer } from './metadata-normalizer.js';
+import { EmbeddingProviderFactory } from './embeddings.js';
+import { VectorStoreFactory } from './vector-store.js';
+import { RouterIngestor } from './ingestor.js';
+import { RouterRetriever } from './retriever.js';
+import { QueryCache } from './cache.js';
+
+export class MCPRouterService {
+  constructor(options = {}) {
+    this.config = options.config || new RouterConfig(options);
+    this.normalizer = new MetadataNormalizer();
+    this.cache = new QueryCache(this.config.cacheTtlMs, options.cacheSize || 200);
+    this.initialized = false;
+  }
+
+  async init() {
+    if (this.initialized) return;
+    this.embeddingProvider = await EmbeddingProviderFactory.create({
+      embeddingProvider: this.config.embeddingProvider,
+      apiKey: this.config.embeddingApiKey,
+      model: this.config.embeddingModel,
+      endpoint: this.config.embeddingEndpoint,
+      dimension: this.config.embeddingDimension
+    });
+    this.vectorStore = await VectorStoreFactory.create(this.config);
+    this.ingestor = new RouterIngestor({
+      config: this.config,
+      vectorStore: this.vectorStore,
+      embeddingProvider: this.embeddingProvider,
+      normalizer: this.normalizer
+    });
+    this.retriever = new RouterRetriever({
+      config: this.config,
+      vectorStore: this.vectorStore,
+      embeddingProvider: this.embeddingProvider
+    });
+    this.initialized = true;
+
+    if (this.config.autoIngest) {
+      try {
+        await this.ingestor.ingest();
+      } catch (error) {
+        console.warn('Automatic router ingestion failed:', error.message);
+      }
+    }
+  }
+
+  async ingest(options = {}) {
+    await this.init();
+    const start = Date.now();
+    const result = await this.ingestor.ingest(options);
+    this.#emit('ingest', {
+      durationMs: Date.now() - start,
+      count: result.count,
+      sources: result.sources
+    });
+    return result;
+  }
+
+  async retrieve(query, options = {}) {
+    await this.init();
+    const cacheKey = JSON.stringify({ query, options });
+    const cached = this.cache.get(cacheKey);
+    if (cached) {
+      this.#emit('retrieve', {
+        query,
+        durationMs: 0,
+        topK: options.topK || this.config.defaultTopK,
+        count: cached.length,
+        cached: true
+      });
+      return { results: cached, cached: true, durationMs: 0 };
+    }
+
+    const start = Date.now();
+    const results = await this.retriever.retrieve(query, options);
+    this.cache.set(cacheKey, results);
+
+    const durationMs = Date.now() - start;
+    this.#emit('retrieve', {
+      query,
+      durationMs,
+      topK: options.topK || this.config.defaultTopK,
+      count: results.length,
+      cached: false
+    });
+
+    return { results, cached: false, durationMs };
+  }
+
+  #emit(event, payload) {
+    if (!this.config.observability?.enabled) return;
+    const message = {
+      component: 'mcp-router',
+      event,
+      timestamp: new Date().toISOString(),
+      ...payload
+    };
+
+    switch (this.config.observability.emitter) {
+      case 'stdout':
+      case 'console':
+      default:
+        console.debug('[router]', JSON.stringify(message));
+        break;
+    }
+  }
+}
+
+export { RouterConfig, RouterIngestor, RouterRetriever, MetadataNormalizer };

--- a/lib/router/ingestor.js
+++ b/lib/router/ingestor.js
@@ -1,0 +1,223 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { glob } from 'glob';
+import YAML from 'yaml';
+import { MCPRegistry } from '../registry.js';
+import { MCPManager } from '../manager.js';
+import { MetadataNormalizer } from './metadata-normalizer.js';
+
+export class RouterIngestor {
+  constructor({ config, vectorStore, embeddingProvider, normalizer } = {}) {
+    this.config = config;
+    this.vectorStore = vectorStore;
+    this.embeddingProvider = embeddingProvider;
+    this.normalizer = normalizer || new MetadataNormalizer();
+    this.registry = new MCPRegistry();
+  }
+
+  async ingest(options = {}) {
+    const records = await this.loadRecords(options);
+    if (records.length === 0) {
+      return { count: 0, sources: {} };
+    }
+
+    const embeddings = await this.#embedInBatches(records.map((record) => record.text));
+
+    const upsertRecords = records.map((record, index) => ({
+      id: `${record.source}:${record.slug}`,
+      name: record.name,
+      description: record.description,
+      source: record.source,
+      embedding: embeddings[index],
+      text: record.text,
+      metadata: {
+        sourceId: record.sourceId,
+        categories: record.categories,
+        tags: record.tags,
+        command: record.command,
+        args: record.args,
+        env: record.env,
+        sampleCalls: record.sampleCalls,
+        schema: record.schema,
+        raw: record.metadata
+      }
+    }));
+
+    await this.vectorStore.upsert(upsertRecords);
+
+    const sourceCounts = records.reduce((acc, record) => {
+      acc[record.source] = (acc[record.source] || 0) + 1;
+      return acc;
+    }, {});
+
+    return {
+      count: upsertRecords.length,
+      sources: sourceCounts
+    };
+  }
+
+  async loadRecords(options = {}) {
+    const records = new Map();
+
+    const loaders = [
+      this.#loadRegistryRecords(),
+      this.#loadProjectConfigRecords(),
+      this.#loadDynamicRecords(),
+      this.#loadAdditionalDefinitions(),
+      this.#loadRemoteRegistries()
+    ];
+
+    const results = await Promise.all(loaders);
+    for (const result of results) {
+      for (const record of result) {
+        records.set(`${record.source}:${record.slug}`, record);
+      }
+    }
+
+    return Array.from(records.values());
+  }
+
+  async #loadRegistryRecords() {
+    const registry = this.registry.getAll();
+    return Object.entries(registry).map(([id, info]) =>
+      this.normalizer.normalize({
+        id,
+        ...info,
+        source: 'registry'
+      })
+    );
+  }
+
+  async #loadProjectConfigRecords() {
+    const manager = new MCPManager(this.config?.projectRoot);
+    try {
+      const config = await manager.load();
+      return Object.entries(config.mcpServers || {}).map(([id, info]) => {
+        const registryInfo = this.registry.get(id) || {};
+        return this.normalizer.normalize({
+          id,
+          source: 'project',
+          name: registryInfo.name || id,
+          description: registryInfo.description || info.description,
+          categories: registryInfo.categories,
+          tags: registryInfo.tags,
+          command: info.command,
+          args: info.args,
+          env: info.env
+        });
+      });
+    } catch (error) {
+      if (error.code !== 'ENOENT') {
+        console.warn('Failed to load project MCP config:', error.message);
+      }
+      return [];
+    }
+  }
+
+  async #loadDynamicRecords() {
+    const dynamicDir = path.join(this.config?.projectRoot || process.cwd(), this.config?.dynamicConfigDir || '.claude');
+    const patterns = ['dynamic-mcps/**/*.json', 'dynamic-mcps/**/*.yaml', 'dynamic-mcps/**/*.yml'];
+    const records = [];
+
+    for (const pattern of patterns) {
+      const files = await glob(path.join(dynamicDir, pattern), { nodir: true, absolute: true });
+      for (const file of files) {
+        try {
+          const data = await this.#parseFile(file);
+          const items = Array.isArray(data) ? data : [data];
+          for (const item of items) {
+            const normalized = this.normalizer.normalize({
+              ...item,
+              source: 'dynamic',
+              sourceId: file
+            });
+            records.push(normalized);
+          }
+        } catch (error) {
+          console.warn(`Failed to parse dynamic MCP file ${file}:`, error.message);
+        }
+      }
+    }
+
+    return records;
+  }
+
+  async #loadAdditionalDefinitions() {
+    const records = [];
+    for (const pattern of this.config?.additionalGlobs || []) {
+      const files = await glob(pattern, { nodir: true, absolute: true });
+      for (const file of files) {
+        try {
+          const data = await this.#parseFile(file);
+          const items = Array.isArray(data) ? data : [data];
+          for (const item of items) {
+            const normalized = this.normalizer.normalize({
+              ...item,
+              source: 'custom',
+              sourceId: file
+            });
+            records.push(normalized);
+          }
+        } catch (error) {
+          console.warn(`Failed to parse custom MCP file ${file}:`, error.message);
+        }
+      }
+    }
+    return records;
+  }
+
+  async #loadRemoteRegistries() {
+    const records = [];
+    for (const url of this.config?.remoteRegistries || []) {
+      try {
+        const response = await fetch(url);
+        if (!response.ok) {
+          console.warn(`Failed to fetch remote registry ${url}: ${response.status}`);
+          continue;
+        }
+        const text = await response.text();
+        const data = this.#parseContent(text, url);
+        const items = Array.isArray(data) ? data : [data];
+        for (const item of items) {
+          const normalized = this.normalizer.normalize({
+            ...item,
+            source: 'remote',
+            sourceId: url
+          });
+          records.push(normalized);
+        }
+      } catch (error) {
+        console.warn(`Failed to load remote registry ${url}:`, error.message);
+      }
+    }
+    return records;
+  }
+
+  async #parseFile(file) {
+    const ext = path.extname(file).toLowerCase();
+    const content = await fs.readFile(file, 'utf-8');
+    return this.#parseContent(content, file, ext);
+  }
+
+  #parseContent(content, source, ext) {
+    const extension = ext || path.extname(source).toLowerCase();
+    if (extension === '.yaml' || extension === '.yml') {
+      return YAML.parse(content);
+    }
+    try {
+      return JSON.parse(content);
+    } catch (error) {
+      throw new Error(`Unsupported format for ${source}`);
+    }
+  }
+
+  async #embedInBatches(texts, batchSize = 32) {
+    const vectors = [];
+    for (let i = 0; i < texts.length; i += batchSize) {
+      const batch = texts.slice(i, i + batchSize);
+      const result = await this.embeddingProvider.embed(batch);
+      vectors.push(...result);
+    }
+    return vectors;
+  }
+}

--- a/lib/router/metadata-normalizer.js
+++ b/lib/router/metadata-normalizer.js
@@ -1,0 +1,144 @@
+import crypto from 'crypto';
+
+export class MetadataNormalizer {
+  constructor(options = {}) {
+    this.defaultSource = options.defaultSource || 'registry';
+  }
+
+  normalize(raw) {
+    if (!raw) {
+      throw new Error('Cannot normalize empty metadata payload');
+    }
+
+    const id = this.#resolveId(raw);
+    const name = raw.name || raw.title || id;
+    const description = raw.description || raw.summary || '';
+    const categories = this.#toArray(raw.categories || raw.tags || []);
+    const tools = this.#normalizeTools(raw.tools || raw.capabilities?.tools);
+    const resources = this.#normalizeResources(raw.resources || raw.capabilities?.resources);
+    const sampleCalls = this.#normalizeSamples(raw.sampleCalls || raw.examples || []);
+
+    const normalized = {
+      id,
+      slug: this.#slugify(id || name),
+      name,
+      description,
+      categories,
+      tags: this.#toArray(raw.tags || []),
+      tools,
+      resources,
+      sampleCalls,
+      command: raw.command || raw.run?.command,
+      args: raw.args || raw.run?.args || [],
+      env: raw.env || raw.environment || {},
+      schema: {
+        tools,
+        resources
+      },
+      source: raw.source || this.defaultSource,
+      sourceId: raw.sourceId || raw.id || id,
+      metadata: this.#stripInternal(raw)
+    };
+
+    normalized.text = this.#buildEmbeddingText(normalized);
+
+    return normalized;
+  }
+
+  #resolveId(raw) {
+    if (raw.uid) return String(raw.uid);
+    if (raw.id) return String(raw.id);
+    if (raw.slug) return raw.slug;
+    if (raw.name) return this.#slugify(raw.name);
+    if (raw.title) return this.#slugify(raw.title);
+
+    const hash = crypto.createHash('sha1');
+    hash.update(JSON.stringify(raw));
+    return hash.digest('hex');
+  }
+
+  #slugify(value) {
+    return (
+      String(value)
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '') || 'mcp'
+    );
+  }
+
+  #toArray(value) {
+    if (!value) return [];
+    if (Array.isArray(value)) return value.filter(Boolean).map(String);
+    if (typeof value === 'string') return value.split(/[;,]/).map((item) => item.trim()).filter(Boolean);
+    return [String(value)];
+  }
+
+  #normalizeTools(tools) {
+    if (!tools) return [];
+
+    if (Array.isArray(tools)) {
+      return tools
+        .map((tool) => this.#normalizeTool(tool))
+        .filter(Boolean);
+    }
+
+    if (typeof tools === 'object') {
+      return Object.entries(tools)
+        .map(([name, value]) => this.#normalizeTool({ name, ...value }))
+        .filter(Boolean);
+    }
+
+    return [];
+  }
+
+  #normalizeTool(tool) {
+    if (!tool) return null;
+    return {
+      name: tool.name || tool.id,
+      description: tool.description || tool.summary || '',
+      inputSchema: tool.inputSchema || tool.schema || tool.input_schema || { type: 'object', properties: {} },
+      outputSchema: tool.outputSchema || tool.output_schema,
+      examples: this.#normalizeSamples(tool.examples || tool.sampleCalls)
+    };
+  }
+
+  #normalizeResources(resources) {
+    if (!resources) return [];
+    if (Array.isArray(resources)) return resources;
+    if (typeof resources === 'object') {
+      return Object.entries(resources).map(([name, value]) => ({ name, ...value }));
+    }
+    return [];
+  }
+
+  #normalizeSamples(samples) {
+    if (!samples) return [];
+    if (Array.isArray(samples)) return samples;
+    if (typeof samples === 'string') return [samples];
+    return [];
+  }
+
+  #stripInternal(raw) {
+    const { tools, capabilities, ...rest } = raw;
+    return rest;
+  }
+
+  #buildEmbeddingText(record) {
+    const parts = [
+      record.id,
+      record.name,
+      record.description,
+      record.categories.join(' '),
+      record.tags.join(' '),
+      record.tools.map((tool) => `${tool.name}: ${tool.description}`).join('\n'),
+      record.sampleCalls.join('\n'),
+      JSON.stringify(record.schema)
+    ];
+
+    return parts
+      .flat()
+      .filter(Boolean)
+      .join('\n')
+      .trim();
+  }
+}

--- a/lib/router/retriever.js
+++ b/lib/router/retriever.js
@@ -1,0 +1,38 @@
+export class RouterRetriever {
+  constructor({ config, vectorStore, embeddingProvider } = {}) {
+    this.config = config;
+    this.vectorStore = vectorStore;
+    this.embeddingProvider = embeddingProvider;
+  }
+
+  async retrieve(query, options = {}) {
+    if (!query) return [];
+    const [embedding] = await this.embeddingProvider.embed([query]);
+    const matches = await this.vectorStore.query(embedding, {
+      topK: options.topK || this.config?.defaultTopK,
+      filter: options.filter
+    });
+
+    return matches.map((match) => this.#toResult(match));
+  }
+
+  #toResult(match) {
+    const metadata = match.metadata || {};
+    return {
+      id: match.id,
+      score: match.score,
+      name: match.name || metadata.name,
+      description: match.description || metadata.description,
+      source: match.source || metadata.source,
+      categories: metadata.categories || [],
+      tags: metadata.tags || [],
+      command: metadata.command,
+      args: metadata.args,
+      env: metadata.env,
+      sampleCalls: metadata.sampleCalls || [],
+      schema: metadata.schema,
+      sourceId: metadata.sourceId,
+      raw: metadata.raw
+    };
+  }
+}

--- a/lib/router/vector-store.js
+++ b/lib/router/vector-store.js
@@ -1,0 +1,298 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+class BaseVectorStore {
+  constructor(config = {}) {
+    this.config = config;
+  }
+
+  async init() {}
+
+  async upsert(records) {
+    throw new Error('upsert(records) must be implemented by subclasses');
+  }
+
+  async query(embedding, options = {}) {
+    throw new Error('query(embedding) must be implemented by subclasses');
+  }
+}
+
+class MemoryVectorStore extends BaseVectorStore {
+  constructor(config = {}) {
+    super(config);
+    this.indexPath = config.memoryStorePath;
+    this.points = [];
+  }
+
+  async init() {
+    if (!this.indexPath) return;
+    try {
+      const data = await fs.readFile(this.indexPath, 'utf-8');
+      const parsed = JSON.parse(data);
+      this.points = parsed.points || [];
+    } catch (error) {
+      if (error.code !== 'ENOENT') {
+        console.warn('Failed to load router memory store:', error.message);
+      }
+    }
+  }
+
+  async upsert(records) {
+    const existingIds = new Map(this.points.map((point) => [point.id, point]));
+    for (const record of records) {
+      existingIds.set(record.id, record);
+    }
+    this.points = Array.from(existingIds.values());
+
+    if (this.indexPath) {
+      await fs.mkdir(path.dirname(this.indexPath), { recursive: true });
+      await fs.writeFile(this.indexPath, JSON.stringify({ points: this.points }, null, 2));
+    }
+
+    return { count: records.length };
+  }
+
+  async query(embedding, options = {}) {
+    const topK = options.topK || this.config.defaultTopK || 5;
+
+    const scored = this.points
+      .map((point) => ({
+        point,
+        score: this.#cosineSimilarity(embedding, point.embedding)
+      }))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, topK);
+
+    return scored.map(({ point, score }) => ({ ...point, score }));
+  }
+
+  #cosineSimilarity(a, b) {
+    if (!a || !b) return 0;
+    const length = Math.min(a.length, b.length);
+    let dot = 0;
+    let normA = 0;
+    let normB = 0;
+
+    for (let i = 0; i < length; i++) {
+      dot += a[i] * b[i];
+      normA += a[i] * a[i];
+      normB += b[i] * b[i];
+    }
+
+    normA = Math.sqrt(normA) || 1;
+    normB = Math.sqrt(normB) || 1;
+    return dot / (normA * normB);
+  }
+}
+
+class SupabaseVectorStore extends BaseVectorStore {
+  async init() {
+    let supabaseModule;
+    try {
+      supabaseModule = await import('@supabase/supabase-js');
+    } catch (error) {
+      throw new Error('Supabase vector store requires @supabase/supabase-js. Install it with `npm install @supabase/supabase-js`.');
+    }
+    const { createClient } = supabaseModule;
+    if (!this.config.vectorStoreUrl || !this.config.vectorStoreApiKey) {
+      throw new Error('Supabase vector store requires ROUTER_VECTOR_STORE_URL and ROUTER_VECTOR_STORE_API_KEY');
+    }
+    this.client = createClient(this.config.vectorStoreUrl, this.config.vectorStoreApiKey, {
+      auth: { persistSession: false }
+    });
+  }
+
+  async upsert(records) {
+    const payload = records.map((record) => ({
+      id: record.id,
+      embedding: record.embedding,
+      metadata: record.metadata,
+      name: record.name,
+      description: record.description,
+      source: record.source
+    }));
+
+    let query = this.client.from(this.config.supabase.table);
+    if (this.config.supabase.schema) {
+      query = query.schema(this.config.supabase.schema);
+    }
+
+    const { error } = await query.upsert(payload, { onConflict: 'id' });
+    if (error) {
+      throw new Error(`Supabase upsert failed: ${error.message}`);
+    }
+
+    return { count: records.length };
+  }
+
+  async query(embedding, options = {}) {
+    const matchFn = this.config.supabase.matchFn;
+    const topK = options.topK || this.config.defaultTopK || 5;
+    const filters = options.filter || {};
+
+    const { data, error } = await this.client.rpc(matchFn, {
+      query_embedding: embedding,
+      match_count: topK,
+      filter: filters
+    });
+
+    if (error) {
+      throw new Error(`Supabase match function failed: ${error.message}`);
+    }
+
+    return (data || []).map((item) => ({
+      id: item.id,
+      score: item.score,
+      embedding: item.embedding,
+      name: item.name,
+      description: item.description,
+      source: item.source,
+      metadata: item.metadata
+    }));
+  }
+}
+
+class QdrantVectorStore extends BaseVectorStore {
+  async init() {
+    let qdrantModule;
+    try {
+      qdrantModule = await import('@qdrant/js-client-rest');
+    } catch (error) {
+      throw new Error('Qdrant vector store requires @qdrant/js-client-rest. Install it with `npm install @qdrant/js-client-rest`.');
+    }
+    const { QdrantClient } = qdrantModule;
+    this.client = new QdrantClient({
+      url: this.config.vectorStoreUrl,
+      apiKey: this.config.vectorStoreApiKey,
+      timeout: this.config.qdrant.timeout
+    });
+
+    const collections = await this.client.getCollections();
+    const exists = collections.collections.some((collection) => collection.name === this.config.qdrant.collection);
+    if (!exists) {
+      await this.client.createCollection(this.config.qdrant.collection, {
+        vectors: {
+          size: this.config.embeddingDimension || 1536,
+          distance: 'Cosine'
+        }
+      });
+    }
+  }
+
+  async upsert(records) {
+    await this.client.upsert(this.config.qdrant.collection, {
+      points: records.map((record) => ({
+        id: record.id,
+        vector: record.embedding,
+        payload: {
+          name: record.name,
+          description: record.description,
+          source: record.source,
+          metadata: record.metadata
+        }
+      }))
+    });
+    return { count: records.length };
+  }
+
+  async query(embedding, options = {}) {
+    const topK = options.topK || this.config.defaultTopK || 5;
+    const filter = options.filter;
+
+    const response = await this.client.search(this.config.qdrant.collection, {
+      vector: embedding,
+      limit: topK,
+      filter
+    });
+
+    return response.map((item) => ({
+      id: item.id,
+      score: item.score,
+      embedding: item.vector,
+      name: item.payload?.name,
+      description: item.payload?.description,
+      source: item.payload?.source,
+      metadata: item.payload?.metadata
+    }));
+  }
+}
+
+class ChromaVectorStore extends BaseVectorStore {
+  async init() {
+    let chromaModule;
+    try {
+      chromaModule = await import('chromadb');
+    } catch (error) {
+      throw new Error('Chroma vector store requires chromadb. Install it with `npm install chromadb`.');
+    }
+    const { ChromaClient } = chromaModule;
+    this.client = new ChromaClient({
+      path: this.config.vectorStoreUrl,
+      auth: this.config.vectorStoreApiKey ? { provider: 'token', token: this.config.vectorStoreApiKey } : undefined,
+      tenant: this.config.chroma.tenant,
+      database: this.config.chroma.database
+    });
+
+    this.collection = await this.client.getOrCreateCollection({
+      name: this.config.chroma.collection
+    });
+  }
+
+  async upsert(records) {
+    await this.collection.upsert({
+      ids: records.map((record) => record.id),
+      embeddings: records.map((record) => record.embedding),
+      metadatas: records.map((record) => ({
+        name: record.name,
+        description: record.description,
+        source: record.source,
+        metadata: record.metadata
+      })),
+      documents: records.map((record) => record.text)
+    });
+    return { count: records.length };
+  }
+
+  async query(embedding, options = {}) {
+    const topK = options.topK || this.config.defaultTopK || 5;
+
+    const result = await this.collection.query({
+      queryEmbeddings: [embedding],
+      nResults: topK
+    });
+
+    const ids = result.ids?.[0] || [];
+    const scores = result.distances?.[0] || [];
+    const metadatas = result.metadatas?.[0] || [];
+
+    return ids.map((id, index) => ({
+      id,
+      score: scores[index],
+      metadata: metadatas[index]
+    }));
+  }
+}
+
+export class VectorStoreFactory {
+  static async create(config = {}) {
+    let store;
+    switch (config.vectorStore) {
+      case 'supabase':
+        store = new SupabaseVectorStore(config);
+        break;
+      case 'qdrant':
+        store = new QdrantVectorStore(config);
+        break;
+      case 'chroma':
+        store = new ChromaVectorStore(config);
+        break;
+      case 'memory':
+      default:
+        store = new MemoryVectorStore(config);
+        break;
+    }
+
+    await store.init();
+    return store;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "bin": {
     "wtf-mcp-manager": "./bin/wtf-mcp.js",
     "wtf-mcp": "./bin/wtf-mcp.js",
-    "claude-mcp": "./bin/wtf-mcp.js"
+    "claude-mcp": "./bin/wtf-mcp.js",
+    "wtf-mcp-router": "./bin/wtf-mcp-router.js"
   },
   "scripts": {
     "test": "node test/test-mcp-server.js",


### PR DESCRIPTION
## Summary
- add a router subsystem that normalizes MCP metadata, generates embeddings, and persists them to configurable vector stores
- introduce the `wtf-mcp-router` CLI for ingestion and ad-hoc retrieval across registries, local configs, and custom YAML/JSON definitions
- integrate router-based tool routing into the MCP server and document environment setup, Docker profiles, and observability hooks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e17cc07e508326babb49312c969050