### PR TITLE
Add context router documentation and registry override support

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,64 @@ Common issues:
 
 ---
 
+## 🧱 Deployment & Operations
+
+### Docker Compose quickstart
+
+```yaml
+services:
+  wtf-mcp-manager:
+    image: node:20
+    working_dir: /app
+    volumes:
+      - ./:/app
+      - ./.claude:/app/.claude
+    command: ["npx", "wtf-mcp-manager", "serve"]
+    environment:
+      # Claude / Anthropic credentials for conversational control
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      # Optional: override or supplement registry metadata
+      WTF_MCP_REGISTRY_OVERRIDES: /app/.claude/registry-overrides.json
+    ports:
+      - "8722:8722"
+```
+
+1. Copy the snippet into `docker-compose.yml` inside your project.
+2. Run `docker compose up --build` to boot the server with persistent `.claude` state mounted from the host.
+3. Update `.claude/mcp-config.json` or use the CLI from inside the container to enable/disable MCPs per environment.【F:lib/manager.js†L10-L118】【F:bin/wtf-mcp.js†L33-L121】
+
+### Environment variables at a glance
+
+| MCP | Required env vars | Source |
+|-----|-------------------|--------|
+| Supabase | `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` | `.claude/.env`, secret manager | 
+| Brave Search | `BRAVE_API_KEY` | `.claude/.env`, secret manager |
+| Firecrawl | `FIRECRAWL_API_KEY` | `.claude/.env`, secret manager |
+| GitHub | `GITHUB_TOKEN` | `.claude/.env`, secret manager |
+| Vercel | `VERCEL_TOKEN` | `.claude/.env`, secret manager |
+| AWS | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` | `.claude/.env`, secret manager |
+
+The registry also includes Docker, Playwright, Context7, Semgrep, and other MCPs that do not require secrets by default.【F:lib/registry.js†L5-L121】 Keep secrets out of version control—`wtf-mcp-manager` writes them to `.claude/.env` when you supply values through the CLI prompts.【F:lib/manager.js†L128-L213】【F:bin/wtf-mcp.js†L90-L137】
+
+### Extend metadata without touching code
+
+1. Create `.claude/registry-overrides.json` or point `WTF_MCP_REGISTRY_OVERRIDES` at a JSON file containing new MCP definitions.
+2. Each JSON entry should include the MCP id and its metadata (name, command, args, required env vars, categories).
+3. Restart the server or rerun `wtf-mcp-manager list`—overrides are merged on load, enabling `enable`/`disable` workflows for the new MCPs immediately.【F:lib/registry.js†L1-L121】【F:bin/wtf-mcp.js†L72-L158】
+
+See [docs/router.md](docs/router.md) for architecture diagrams detailing how overrides participate in ingestion and routing.
+
+### Maintenance playbook
+
+| Task | When | How |
+|------|------|-----|
+| Re-index registry metadata | After registry refreshes or override edits | Run `wtf-mcp-manager fetch --force` then rebuild your embeddings or rerun the vectorizer job.【F:lib/mcp-server.js†L120-L188】 |
+| Refresh auto-detection signals | When project structure changes | Execute `wtf-mcp-manager detect` to rescan the repository for MCP hints.【F:bin/wtf-mcp.js†L158-L206】 |
+| Monitor relevance metrics | Continuous | Track match scores returned by your vector store and log how often suggested MCPs are accepted; alert when similarity or acceptance rate dips. |
+| Tune performance | When latency increases | Adjust caching windows (30-minute TTL) and prewarm embeddings for frequently used MCP families.【F:lib/mcp-server.js†L24-L33】【F:docs/router.md†L17-L70】 |
+
+---
+
 ## 🚀 Installation & Publishing
 
 ### Use Directly

--- a/docs/router.md
+++ b/docs/router.md
@@ -1,0 +1,142 @@
+# Context Router Architecture
+
+The WTF-MCP-Manager context router ties together metadata ingestion, vector retrieval, and dynamic routing so Claude can decide which MCPs to activate for any conversation. This document provides visual flows and operational guidance for each stage of the pipeline.
+
+## High-Level Topology
+
+```mermaid
+flowchart LR
+    subgraph Discovery & Generation
+        A[Official MCP Registry] -->|fetch_mcps| B[Registry Parser]
+        A2[Registry Overrides<br/>(.claude/registry-overrides.json)] --> B
+        A3[Local Project Scan<br/>(AutoDetector)] --> C[Project Signals]
+        A4[Dynamic MCP Generator] --> D[Generated MCP Artifacts]
+    end
+
+    subgraph Vector Intelligence
+        B --> E[Metadata Normalizer]
+        C --> E
+        D --> E
+        E --> F[Embedding Worker]
+        F --> G[(Vector Store)]
+    end
+
+    subgraph Routing Runtime
+        G --> H[Context Router]
+        C --> H
+        H --> I[Claude Conversation]
+        H --> J[MCP Enable/Disable]
+    end
+```
+
+## Ingestion Flow
+
+1. **Registry retrieval** – `fetch_mcps` downloads the public registry text and merges it with the built-in catalog so the router has a canonical list of known MCPs.【F:lib/mcp-server.js†L120-L188】
+2. **Override hydration** – Local JSON overrides in `.claude/registry-overrides.json` or any path listed in `WTF_MCP_REGISTRY_OVERRIDES` are merged into the registry at startup, allowing you to extend metadata without editing the codebase.【F:lib/registry.js†L1-L121】
+3. **Project scanning** – `AutoDetector` inspects the repo to surface MCP hints derived from files, configuration, and heuristics.【F:lib/mcp-server.js†L366-L377】
+4. **Dynamic generation** – The generator stores on-the-fly MCP builds in `.claude/dynamic-mcps` so they can be indexed alongside static servers.【F:lib/dynamic/mcp-generator.js†L10-L45】
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Claude
+    participant Router as WTF-MCP-Manager
+    participant Registry as Registry Parser
+    participant Overrides
+    participant Detector
+    participant Generator
+
+    Claude->>Router: tools/call fetch_mcps(force?)
+    Router->>Registry: Fetch & parse registry text
+    Overrides-->>Registry: Merge override entries
+    Registry-->>Router: Normalized MCP metadata
+    Claude->>Router: tools/call auto_detect
+    Router->>Detector: Scan project for signals
+    Detector-->>Router: Detected MCP candidates
+    Claude->>Router: Request dynamic generation
+    Router->>Generator: Build and register MCP artifacts
+    Generator-->>Router: MCP definitions & ports
+```
+
+## Vector Retrieval Flow
+
+After ingestion, metadata is embedded for semantic search so the router can pick the most relevant MCPs for a conversation.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Worker as Embedding Worker
+    participant Metadata
+    participant Store as Vector Store
+    participant Router
+    participant Claude
+
+    Metadata->>Worker: Normalized MCP payloads
+    Worker->>Store: Upsert vectors & metadata
+    Claude->>Router: Provide task / question
+    Router->>Store: Similarity query (top-k)
+    Store-->>Router: Ranked MCP candidates + scores
+    Router-->>Claude: Context bundle with rationale
+```
+
+### Implementation Notes
+
+- **Batching** – Process registry entries in batches (100–200) to avoid embedding rate limits when refreshing the catalogue.
+- **Metadata payload** – Include `id`, `description`, `categories`, required env vars, and project heuristics for best recall.
+- **Storage options** – Start with a lightweight SQLite + `sqlite-vector` bundle for local workflows, then graduate to Postgres/pgvector or managed vector stores if latency or scale require it.
+
+## Context Routing Flow
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Claude
+    participant Router
+    participant Store as Vector Store
+    participant Manager as MCP Manager
+
+    Claude->>Router: Task context
+    Router->>Store: Retrieve similar MCP vectors
+    Store-->>Router: Candidate MCPs with scores
+    Router->>Manager: enable_mcp/disable_mcp as needed
+    Manager-->>Router: Confirmation & env guidance
+    Router-->>Claude: Recommended MCP set + explanations
+```
+
+### Routing Heuristics
+
+1. **Vector similarity** – Start with cosine similarity across embeddings to prune the candidate list.
+2. **Constraint filtering** – Drop MCPs that are missing required environment variables or conflict with the active profile before surfacing them.【F:lib/manager.js†L128-L205】
+3. **Conversation memory** – Prefer MCPs already active in the current `.claude` profile unless the new task demands replacements.
+4. **Human-in-the-loop** – Always return rationale tokens so Claude can explain why a tool is suggested and ask the user for confirmation before enabling it.
+
+## Metadata Source Playbook
+
+1. Create `.claude/registry-overrides.json` (or point `WTF_MCP_REGISTRY_OVERRIDES` at a JSON file). Each entry should map an MCP id to its metadata payload:
+
+   ```json
+   {
+     "custom-weather": {
+       "name": "Custom Weather",
+       "package": "@acme/mcp-weather",
+       "command": "npx",
+       "args": ["-y", "@acme/mcp-weather"],
+       "requiredEnv": ["ACME_WEATHER_TOKEN"],
+       "description": "Internal weather API"
+     }
+   }
+   ```
+
+2. Restart the manager or re-run the CLI command. The override is merged automatically, so `list` and `enable` now understand the new MCP without touching the source code.【F:lib/registry.js†L43-L121】
+3. Store secrets in `.claude/.env` or your secret manager; the router only needs identifiers and connection metadata in the override file.【F:lib/manager.js†L128-L213】
+
+## Operational Tasks
+
+- **Re-index metadata** – Run `wtf-mcp-manager fetch --force` followed by your embedding job to rebuild vectors after large registry changes.【F:lib/mcp-server.js†L120-L188】
+- **Monitor retrieval quality** – Track hit rates for `tools/list` recommendations and set alerts when similarity scores drop below historical baselines.
+- **Performance tuning** – Cache registry fetches (30-minute TTL) and warm the vector store with recent conversations to minimize cold-start latency.【F:lib/mcp-server.js†L24-L33】【F:lib/mcp-server.js†L120-L188】
+
+## Further Reading
+
+- `README.md` – Deployment, Docker Compose, and maintenance checklists.
+- `docs/mcp-complete-implementation-guide.md` – End-to-end MCP implementation patterns.

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -1,3 +1,6 @@
+import { readFileSync, existsSync } from 'fs';
+import path from 'path';
+
 /**
  * MCP Registry
  * Central registry of all known MCPs
@@ -123,6 +126,8 @@ export class MCPRegistry {
         autoDetect: ['serverless.yml', '.aws/', 'sam.yml']
       }
     };
+
+    this.loadOverrides();
   }
 
   get(mcpId) {
@@ -179,5 +184,88 @@ export class MCPRegistry {
 
   remove(mcpId) {
     delete this.registry[mcpId];
+  }
+
+  loadOverrides() {
+    const overridePaths = new Set();
+
+    const envOverrides = process.env.WTF_MCP_REGISTRY_OVERRIDES;
+    if (envOverrides) {
+      envOverrides
+        .split(',')
+        .map(pathStr => pathStr.trim())
+        .filter(Boolean)
+        .forEach(pathStr => {
+          const absolute = path.isAbsolute(pathStr)
+            ? pathStr
+            : path.resolve(process.cwd(), pathStr);
+          overridePaths.add(absolute);
+        });
+    }
+
+    const defaultPath = path.join(process.cwd(), '.claude', 'registry-overrides.json');
+    if (existsSync(defaultPath)) {
+      overridePaths.add(defaultPath);
+    }
+
+    for (const filePath of overridePaths) {
+      if (!existsSync(filePath)) continue;
+
+      try {
+        const raw = readFileSync(filePath, 'utf-8');
+        const parsed = JSON.parse(raw);
+
+        if (Array.isArray(parsed)) {
+          parsed.forEach(entry => this.applyOverrideEntry(entry));
+        } else if (parsed && typeof parsed === 'object') {
+          Object.entries(parsed).forEach(([id, info]) => {
+            this.applyOverrideEntry({ id, ...info });
+          });
+        }
+      } catch (error) {
+        console.warn(`Failed to load registry overrides from ${filePath}: ${error.message}`);
+      }
+    }
+  }
+
+  applyOverrideEntry(entry) {
+    if (!entry || typeof entry !== 'object') return;
+
+    const { id: explicitId, ...rest } = entry;
+    const mcpId = typeof explicitId === 'string' && explicitId.trim()
+      ? explicitId.trim()
+      : typeof rest.id === 'string' && rest.id.trim()
+        ? rest.id.trim()
+        : null;
+
+    if (!mcpId) return;
+
+    const normalizedInfo = { ...rest };
+    delete normalizedInfo.id;
+
+    const existing = this.registry[mcpId] || {};
+    this.registry[mcpId] = {
+      ...existing,
+      ...normalizedInfo
+    };
+
+    if (!this.registry[mcpId].name) {
+      this.registry[mcpId].name = this.formatNameFromId(mcpId);
+    }
+
+    if (!this.registry[mcpId].command && this.registry[mcpId].package) {
+      this.registry[mcpId].command = 'npx';
+      this.registry[mcpId].args = ['-y', this.registry[mcpId].package];
+    }
+
+    this.registry[mcpId].source = normalizedInfo.source || existing.source || 'override';
+  }
+
+  formatNameFromId(id) {
+    return id
+      .split('-')
+      .filter(Boolean)
+      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(' ');
   }
 }


### PR DESCRIPTION
## Summary
- add a dedicated context router guide covering ingestion, vector retrieval, and routing flows
- document docker compose setup, environment variables, and maintenance guidance in the README
- allow registry metadata overrides to be loaded from configuration files or environment variables

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e17dc559a883268f6f94d8d1dab408