### PR TITLE
Add Docker orchestration and vector DB health checks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+.git
+.gitignore
+.env
+.env.*
+secrets/
+dist
+build
+coverage

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Copy this file to .env and customize as needed
+ROUTER_PORT=3000
+VECTOR_DB_URL=http://vector-db:6333
+VECTOR_DB_PORT=6333
+# Optional: only required if your Qdrant instance enforces API keys
+VECTOR_DB_API_KEY=
+# Path to Docker secret containing the API key (used by docker compose)
+VECTOR_DB_API_KEY_FILE=./secrets/vector_db_api_key

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,10 @@ build
 .env.test.local
 .env.production.local
 
+# Docker secrets
+secrets/*
+!secrets/.gitkeep
+
 # IDE
 .idea
 .vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1
+
+FROM node:20-alpine AS base
+WORKDIR /app
+
+# Install production dependencies first for better caching
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+# Copy application source
+COPY bin ./bin
+COPY lib ./lib
+COPY scripts ./scripts
+COPY docs ./docs
+COPY mcp-tools.json ./mcp-tools.json
+
+# Ensure CLI entrypoint is executable
+RUN chmod +x bin/wtf-mcp.js
+
+ENV NODE_ENV=production
+
+# The meta MCP server acts as the router
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 CMD ["node", "scripts/healthcheck.js"]
+
+CMD ["node", "lib/mcp-server.js"]

--- a/README.md
+++ b/README.md
@@ -329,6 +329,36 @@ npm install
 npm test
 ```
 
+#### Containerised local stack
+
+1. Copy `.env.example` to `.env` and update any variables you need.
+2. (Optional) If your Qdrant instance requires an API key, save it to `secrets/vector_db_api_key` (this path is mounted as a Docker secret).
+3. Start the router and vector database:
+
+   ```bash
+   npm run compose:up
+   ```
+
+4. Tail logs from the router service:
+
+   ```bash
+   npm run compose:logs
+   ```
+
+5. Run the smoke test to verify that the router can talk to the vector database:
+
+   ```bash
+   npm run compose:test
+   ```
+
+6. Tear the stack down when you're done:
+
+   ```bash
+   npm run compose:down
+   ```
+
+The router container uses the `scripts/healthcheck.js` probe both for Docker health checks and the smoke test. It will fail fast if `VECTOR_DB_URL` is unreachable or the API key secret is misconfigured.
+
 ---
 
 ## 🎯 The Future is Conversational

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+version: '3.9'
+
+services:
+  router:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    env_file:
+      - .env
+    environment:
+      VECTOR_DB_URL: ${VECTOR_DB_URL:-http://vector-db:6333}
+      VECTOR_DB_API_KEY_FILE: /run/secrets/vector_db_api_key
+    secrets:
+      - source: vector_db_api_key
+        target: vector_db_api_key
+        optional: true
+    depends_on:
+      vector-db:
+        condition: service_healthy
+    ports:
+      - "${ROUTER_PORT:-3000}:3000"
+    healthcheck:
+      test: ["CMD", "node", "scripts/healthcheck.js"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    restart: unless-stopped
+
+  vector-db:
+    image: qdrant/qdrant:latest
+    ports:
+      - "${VECTOR_DB_PORT:-6333}:6333"
+    volumes:
+      - qdrant_storage:/qdrant/storage
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:6333/healthz"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+volumes:
+  qdrant_storage:
+
+secrets:
+  vector_db_api_key:
+    file: ${VECTOR_DB_API_KEY_FILE:-./secrets/vector_db_api_key}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,11 @@
     "lint": "eslint lib/",
     "prepare": "npm run build",
     "build": "echo 'Build complete'",
-    "postinstall": "node scripts/postinstall.js || true"
+    "postinstall": "node scripts/postinstall.js || true",
+    "compose:up": "docker compose --env-file .env up --build -d",
+    "compose:down": "docker compose --env-file .env down",
+    "compose:logs": "docker compose --env-file .env logs -f router",
+    "compose:test": "docker compose --env-file .env run --rm router node scripts/healthcheck.js"
   },
   "keywords": [
     "claude",

--- a/scripts/healthcheck.js
+++ b/scripts/healthcheck.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+
+import 'dotenv/config';
+import { readFile } from 'fs/promises';
+
+const DEFAULT_VECTOR_DB_URL = 'http://vector-db:6333';
+const VECTOR_DB_HEALTH_PATH = 'healthz';
+
+async function resolveApiKey() {
+  if (process.env.VECTOR_DB_API_KEY) {
+    return process.env.VECTOR_DB_API_KEY;
+  }
+
+  const secretFile = process.env.VECTOR_DB_API_KEY_FILE;
+  if (!secretFile) {
+    return undefined;
+  }
+
+  try {
+    const fileContents = await readFile(secretFile, 'utf8');
+    const value = fileContents.trim();
+    if (value) {
+      process.env.VECTOR_DB_API_KEY = value;
+      return value;
+    }
+  } catch (error) {
+    console.warn(`⚠️  Unable to read vector DB API key from ${secretFile}: ${error.message}`);
+  }
+  return undefined;
+}
+
+function buildHealthUrl(baseUrl) {
+  const normalized = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+  return `${normalized}${VECTOR_DB_HEALTH_PATH}`;
+}
+
+async function checkVectorDbConnection() {
+  const baseUrl = process.env.VECTOR_DB_URL || DEFAULT_VECTOR_DB_URL;
+  const healthUrl = buildHealthUrl(baseUrl);
+  const apiKey = await resolveApiKey();
+
+  const headers = {};
+  if (apiKey) {
+    headers['api-key'] = apiKey;
+  }
+
+  const response = await fetch(healthUrl, { headers });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Vector DB health check failed (${response.status}): ${text}`);
+  }
+
+  const payload = await response.json().catch(() => ({}));
+  console.log('✅ Vector database reachable at', baseUrl, payload);
+}
+
+checkVectorDbConnection()
+  .then(() => process.exit(0))
+  .catch(error => {
+    console.error('❌ Router failed to connect to vector database:', error.message);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- add a production Dockerfile for the MCP router and compose stack with a co-located Qdrant vector database
- wire npm scripts for bringing the stack up/down, tailing logs, and running the vector-store connectivity smoke test
- provide a reusable healthcheck script, environment template, and documentation for the containerised workflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e17dc46a9c83268cd17a8fcefdc59f