### PR TITLE
Add context router for routing tool manifests

### DIFF
--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -15,6 +15,7 @@ import { MCPRegistry } from './registry.js';
 import { AutoDetector } from './detector.js';
 import { DynamicMCPGenerator } from './dynamic/mcp-generator.js';
 import { APIDiscoveryService } from './discovery/api-discovery.js';
+import { ContextRouter } from './router/context-router.js';
 
 class WTFMCPManagerServer {
   constructor() {
@@ -28,6 +29,7 @@ class WTFMCPManagerServer {
     this.FETCH_CACHE_TTL = 30 * 60 * 1000; // 30 minutes
     this.dynamicMCPs = new Map();
     this.workflows = new Map();
+    this.contextRouter = new ContextRouter();
   }
 
   async initialize() {
@@ -390,6 +392,9 @@ class WTFMCPManagerServer {
         case 'stop_dynamic_mcp':
           return await this.stopDynamicMCP(params.mcpId);
 
+        case 'route_tools':
+          return await this.routeTools(params);
+
         default:
           throw new Error(`Unknown method: ${method}`);
       }
@@ -452,6 +457,27 @@ class WTFMCPManagerServer {
     }
 
     return results.sort((a, b) => b.score - a.score).slice(0, 10);
+  }
+
+  async routeTools(params = {}) {
+    const { query = '', retrieverResults = [], topK } = params;
+
+    let candidates = Array.isArray(retrieverResults) && retrieverResults.length > 0
+      ? retrieverResults
+      : [];
+
+    if (candidates.length === 0 && query) {
+      candidates = await this.searchMCPs(query);
+    }
+
+    const tools = this.contextRouter.format(candidates, { topK });
+
+    return {
+      query: query || null,
+      totalCandidates: candidates.length,
+      topK: Number.isInteger(topK) && topK > 0 ? topK : this.contextRouter.defaultTopK,
+      tools
+    };
   }
 
   async suggestMCPs(requirements) {
@@ -945,6 +971,32 @@ async function runMCPServer() {
                         }
                       },
                       required: ["query"],
+                      additionalProperties: false
+                    }
+                  },
+                  {
+                    name: "route_tools",
+                    description: "Format retriever output into minimal tool manifests for the most relevant MCPs",
+                    inputSchema: {
+                      type: "object",
+                      properties: {
+                        query: {
+                          type: "string",
+                          description: "Optional query used to search the MCP registry"
+                        },
+                        retrieverResults: {
+                          type: "array",
+                          description: "Pre-ranked retriever results to format",
+                          items: {
+                            type: "object"
+                          }
+                        },
+                        topK: {
+                          type: "integer",
+                          description: "Maximum number of tool manifests to return",
+                          minimum: 1
+                        }
+                      },
                       additionalProperties: false
                     }
                   },

--- a/lib/router/context-router.js
+++ b/lib/router/context-router.js
@@ -1,0 +1,106 @@
+/**
+ * ContextRouter
+ * Formats retriever results into minimal tool manifests that can be streamed
+ * back to Claude without leaking entire registries or bulky metadata.
+ */
+
+export class ContextRouter {
+  constructor(options = {}) {
+    const { topK = 5 } = options;
+    this.defaultTopK = Number.isInteger(topK) && topK > 0 ? topK : 5;
+  }
+
+  format(results = [], options = {}) {
+    const { topK } = options;
+    const limit = Number.isInteger(topK) && topK > 0 ? topK : this.defaultTopK;
+    const manifests = [];
+    const seen = new Set();
+
+    if (!Array.isArray(results)) {
+      return manifests;
+    }
+
+    for (const result of results) {
+      const manifest = this.#toManifest(result);
+      if (!manifest) continue;
+
+      const dedupeKey = manifest.name.toLowerCase();
+      if (seen.has(dedupeKey)) {
+        continue;
+      }
+
+      seen.add(dedupeKey);
+      manifests.push(manifest);
+
+      if (manifests.length >= limit) {
+        break;
+      }
+    }
+
+    return manifests;
+  }
+
+  #toManifest(result = {}) {
+    const name = this.#resolveName(result);
+    if (!name) {
+      return null;
+    }
+
+    const description = this.#resolveDescription(result);
+    const inputSchema = this.#resolveSchema(result);
+    const examples = this.#resolveExamples(result);
+
+    return { name, description, inputSchema, examples };
+  }
+
+  #resolveName(result) {
+    return (
+      result?.name ||
+      result?.id ||
+      result?.toolName ||
+      result?.package ||
+      null
+    );
+  }
+
+  #resolveDescription(result) {
+    return (
+      result?.description ||
+      result?.summary ||
+      result?.details ||
+      result?.text ||
+      ''
+    );
+  }
+
+  #resolveSchema(result) {
+    const schema =
+      result?.inputSchema ||
+      result?.schema ||
+      result?.parameters ||
+      result?.args ||
+      result?.exampleSchema;
+
+    if (schema && typeof schema === 'object' && !Array.isArray(schema)) {
+      return schema;
+    }
+
+    return null;
+  }
+
+  #resolveExamples(result) {
+    const { examples, example } = result || {};
+
+    if (Array.isArray(examples)) {
+      return examples;
+    }
+
+    if (example) {
+      return [example];
+    }
+
+    return [];
+  }
+}
+
+export default ContextRouter;

--- a/test/test-mcp-server.js
+++ b/test/test-mcp-server.js
@@ -6,6 +6,7 @@
 
 import { WTFMCPManagerServer } from '../lib/mcp-server.js';
 import chalk from 'chalk';
+import assert from 'assert/strict';
 
 async function runTests() {
   console.log(chalk.cyan('\n🧪 Testing WTF-MCP-Manager Meta Server\n'));
@@ -103,6 +104,27 @@ async function runTests() {
     });
   } catch (error) {
     console.log(chalk.red('❌ Diagnostics failed:'), error.message);
+  }
+
+  // Test 8: Route Tools Metadata
+  console.log(chalk.yellow('\n8. Testing tool routing metadata...'));
+  try {
+    const routed = await server.handleRequest('route_tools', { query: 'database', topK: 2 });
+    console.log(chalk.green('✅ Tool routing metadata:'));
+    console.log(`   Returned tools: ${routed.tools.length}`);
+    console.log(`   Total candidates seen: ${routed.totalCandidates}`);
+
+    assert(routed.tools.length <= 2, 'Route tools should respect topK limit');
+    const allowedKeys = ['name', 'description', 'inputSchema', 'examples'];
+    routed.tools.forEach(tool => {
+      Object.keys(tool).forEach(key => {
+        assert(allowedKeys.includes(key), `Unexpected key emitted in routed tool metadata: ${key}`);
+      });
+    });
+
+    assert(!('rawText' in routed), 'Route tools response should not expose raw registry text');
+  } catch (error) {
+    console.log(chalk.red('❌ Tool routing failed:'), error.message);
   }
 
   console.log(chalk.cyan('\n🎯 All tests completed!\n'));


### PR DESCRIPTION
## Summary
- add a context router helper that normalizes retriever hits into compact tool manifests
- expose a `route_tools` RPC that returns only the routed metadata and advertise it through `tools/list`
- extend the protocol test script to assert the top-k limit and metadata-only payloads

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e17dc32bf0832693c5829251301934