### PR TITLE
feat: add vector store ingestion pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@ Main commands accessible via `npx wtf-mcp-manager` or aliases `wtf-mcp`, `claude
 - `enable <mcp> [--env KEY=value]` - Enable an MCP with optional env vars
 - `disable <mcp>` - Disable an MCP
 - `detect` - Auto-detect needed MCPs based on project
+- `ingest` - Embed MCP metadata into a configured vector store
 - `serve` - Start Meta-MCP server for Claude integration
 - `global <list|disable> [mcp]` - Manage global Claude MCPs
 - `doctor` - Diagnose configuration issues

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ npx wtf-mcp-manager init                # Initialize project
 npx wtf-mcp-manager list                # Show all MCPs
 npx wtf-mcp-manager enable supabase     # Enable specific MCP
 npx wtf-mcp-manager detect              # Auto-detect MCPs
+npx wtf-mcp-manager ingest --provider memory  # Embed metadata into a vector DB
 npx wtf-mcp-manager doctor              # Diagnose issues
 ```
 
@@ -83,6 +84,47 @@ npx wtf-mcp-manager doctor              # Diagnose issues
 ```
 
 **Then just talk to Claude naturally and it will manage everything!**
+
+---
+
+## 📚 Embed MCP knowledge into your vector store
+
+The `ingest` command exports registry entries, discovery metadata, and `mcp-tools.json` definitions into a vector database so your LLM can retrieve rich MCP knowledge.
+
+```bash
+npx wtf-mcp-manager ingest \
+  --provider chroma \
+  --collection mcp_metadata
+```
+
+### Required environment variables
+
+The CLI loads credentials from `.claude/.env` (created during `wtf-mcp-manager init`). Set the variables that match your stack:
+
+| Purpose | Variable | Notes |
+|---------|----------|-------|
+| Vector database selection | `VECTOR_DB_PROVIDER` | `memory`, `chroma`, `qdrant`, or `supabase` |
+| Vector DB auth | `VECTOR_DB_API_KEY` | API key/token if required by your provider |
+| Vector DB location | `VECTOR_DB_URL` | Base URL for Chroma/Qdrant/Supabase REST endpoint |
+| Collection/table | `VECTOR_DB_COLLECTION` | Collection/namespace for Chroma & Qdrant |
+| Supabase table | `VECTOR_DB_TABLE` | Table containing `embedding` + metadata columns |
+| Embedding provider | `EMBEDDING_PROVIDER` | `mock` (default) or `openai` |
+| Embedding endpoint | `EMBEDDING_ENDPOINT` | Override HTTP endpoint (optional) |
+| Embedding model | `EMBEDDING_MODEL` | Model identifier (e.g., `text-embedding-3-large`) |
+| Embedding API key | `EMBEDDING_API_KEY` | Secret for your embedding provider |
+
+Example `.claude/.env` snippet:
+
+```env
+VECTOR_DB_PROVIDER=chroma
+VECTOR_DB_URL=http://localhost:8000
+VECTOR_DB_COLLECTION=mcp_metadata
+EMBEDDING_PROVIDER=openai
+EMBEDDING_API_KEY=sk-...
+EMBEDDING_MODEL=text-embedding-3-large
+```
+
+Run `wtf-mcp-manager ingest` any time you update MCP definitions to sync the knowledge base.
 
 ---
 

--- a/bin/wtf-mcp.js
+++ b/bin/wtf-mcp.js
@@ -15,6 +15,7 @@ import fs from 'fs/promises';
 import { MCPManager } from '../lib/manager.js';
 import { MCPRegistry } from '../lib/registry.js';
 import { AutoDetector } from '../lib/detector.js';
+import { VectorStoreIngestor } from '../lib/router/vector-store.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -226,6 +227,48 @@ program
         await manager.enable(mcp.id);
       }
       console.log(chalk.green('\n✅ All MCPs enabled! WTF, that was quick!'));
+    }
+  });
+
+// Vector store ingestion command
+program
+  .command('ingest')
+  .description('Ingest MCP metadata into the configured vector store')
+  .option('-p, --provider <provider>', 'Vector database provider (memory, chroma, qdrant, supabase)')
+  .option('-u, --url <url>', 'Vector database base URL override')
+  .option('-c, --collection <name>', 'Vector database collection or namespace')
+  .option('-t, --table <name>', 'Supabase table name override')
+  .option('--embedding-provider <provider>', 'Embedding provider (mock, openai)')
+  .option('--embedding-model <model>', 'Embedding model identifier override')
+  .option('--embedding-endpoint <url>', 'Embedding HTTP endpoint override')
+  .option('--env <path>', 'Path to .env file with credentials', join(process.cwd(), '.claude', '.env'))
+  .action(async (options) => {
+    showBanner();
+    const spinner = ora('Ingesting MCP metadata into vector store...').start();
+
+    try {
+      const ingestor = new VectorStoreIngestor({
+        provider: options.provider,
+        vectorProvider: options.provider,
+        url: options.url,
+        collection: options.collection,
+        table: options.table,
+        embeddingProvider: options.embeddingProvider,
+        embeddingModel: options.embeddingModel,
+        embeddingEndpoint: options.embeddingEndpoint,
+        envPath: options.env
+      });
+
+      const result = await ingestor.ingestAll();
+      spinner.succeed(chalk.green(`✅ Ingested ${result.count} documents into ${result.provider} vector store`));
+
+      if (result.ids?.length) {
+        const sampleIds = result.ids.slice(0, 5).join(', ');
+        console.log(chalk.gray(`Sample document IDs: ${sampleIds}${result.ids.length > 5 ? ', ...' : ''}`));
+      }
+    } catch (error) {
+      spinner.fail(chalk.red(`Failed to ingest MCP metadata: ${error.message}`));
+      process.exit(1);
     }
   });
 

--- a/lib/router/vector-store.js
+++ b/lib/router/vector-store.js
@@ -1,0 +1,514 @@
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import fs from 'fs';
+import { readFile } from 'fs/promises';
+import dotenv from 'dotenv';
+import crypto from 'crypto';
+import fetch from 'node-fetch';
+import { MCPRegistry } from '../registry.js';
+import { API_DATABASE } from '../discovery/api-database.js';
+import { WebSearchService } from '../discovery/web-search.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const PROJECT_ROOT = join(__dirname, '..', '..');
+
+function loadClaudeEnv(envPath = join(PROJECT_ROOT, '.claude', '.env')) {
+  if (process.env.__WTF_MCP_ENV_LOADED) {
+    return;
+  }
+
+  try {
+    if (fs.existsSync(envPath)) {
+      dotenv.config({ path: envPath, override: false });
+    }
+  } catch (error) {
+    console.warn('[vector-store] Unable to load .claude/.env:', error.message);
+  }
+
+  process.env.__WTF_MCP_ENV_LOADED = 'true';
+}
+
+function serializeSchema(schema) {
+  if (!schema) return '';
+  if (typeof schema === 'string') return schema;
+  try {
+    return JSON.stringify(schema, null, 2);
+  } catch (error) {
+    return String(schema);
+  }
+}
+
+function normalizeDocument({ id, source, name, description, schema, example, metadata = {} }) {
+  const schemaText = serializeSchema(schema);
+  const exampleText = example || '';
+  const base = {
+    id,
+    source,
+    name,
+    description: description || '',
+    schema,
+    example: exampleText,
+    metadata
+  };
+
+  return {
+    ...base,
+    text: [
+      `Source: ${source}`,
+      name ? `Name: ${name}` : '',
+      description ? `Description: ${description}` : '',
+      schemaText ? `Schema: ${schemaText}` : '',
+      exampleText ? `Example: ${exampleText}` : ''
+    ].filter(Boolean).join('\n')
+  };
+}
+
+function hashToVector(value, dimensions = 8) {
+  const hash = crypto.createHash('sha256').update(value).digest();
+  const vector = [];
+  for (let i = 0; i < dimensions; i++) {
+    const slice = hash.readUInt32BE((i * 4) % hash.length);
+    vector.push((slice / 0xffffffff) * 2 - 1);
+  }
+  return vector;
+}
+
+class EmbeddingClient {
+  constructor({ provider = 'mock', apiKey, model, endpoint } = {}) {
+    this.provider = provider.toLowerCase();
+    this.apiKey = apiKey;
+    this.model = model;
+    this.endpoint = endpoint;
+  }
+
+  async embed(texts) {
+    if (!Array.isArray(texts)) {
+      return this.embed([texts]);
+    }
+
+    switch (this.provider) {
+      case 'openai':
+        return this.embedWithOpenAI(texts);
+      case 'mock':
+      default:
+        return texts.map(text => hashToVector(text));
+    }
+  }
+
+  async embedWithOpenAI(texts) {
+    if (!this.apiKey) {
+      throw new Error('OpenAI API key is required for embeddings');
+    }
+
+    const endpoint = this.endpoint || 'https://api.openai.com/v1/embeddings';
+    const model = this.model || 'text-embedding-3-large';
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${this.apiKey}`
+      },
+      body: JSON.stringify({
+        model,
+        input: texts
+      })
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(`OpenAI embedding failed: ${response.status} ${errorBody}`);
+    }
+
+    const data = await response.json();
+    return data.data.map(item => item.embedding);
+  }
+}
+
+export class MockEmbeddingClient extends EmbeddingClient {
+  constructor() {
+    super({ provider: 'mock' });
+  }
+}
+
+class EmbeddingProviderFactory {
+  static create(options = {}) {
+    if (options.embeddingClient) {
+      return options.embeddingClient;
+    }
+
+    const provider = (options.embeddingProvider || options.provider || process.env.EMBEDDING_PROVIDER || 'mock').toLowerCase();
+    const apiKey = options.embeddingApiKey || options.apiKey || process.env.EMBEDDING_API_KEY;
+    const model = options.embeddingModel || options.model || process.env.EMBEDDING_MODEL;
+    const endpoint = options.embeddingEndpoint || options.endpoint || process.env.EMBEDDING_ENDPOINT;
+
+    return new EmbeddingClient({ provider, apiKey, model, endpoint });
+  }
+}
+
+class AbstractVectorDatabase {
+  constructor(provider) {
+    this.provider = provider;
+  }
+
+  async upsertMany(records) {
+    throw new Error('upsertMany not implemented');
+  }
+}
+
+export class MemoryVectorDatabase extends AbstractVectorDatabase {
+  constructor() {
+    super('memory');
+    this.records = [];
+  }
+
+  async upsertMany(records) {
+    this.records.push(...records);
+  }
+}
+
+class ChromaVectorDatabase extends AbstractVectorDatabase {
+  constructor(options = {}) {
+    super('chroma');
+    this.url = options.url || process.env.VECTOR_DB_URL || 'http://localhost:8000';
+    this.collection = options.collection || process.env.VECTOR_DB_COLLECTION || 'mcp_metadata';
+    this.apiKey = options.apiKey || process.env.VECTOR_DB_API_KEY;
+  }
+
+  async upsertMany(records) {
+    const endpoint = new URL(`/api/v1/collections/${this.collection}/upsert`, this.url).toString();
+    const body = {
+      ids: records.map(record => record.id),
+      embeddings: records.map(record => record.embedding),
+      metadatas: records.map(record => ({
+        source: record.source,
+        name: record.name,
+        description: record.description,
+        example: record.example,
+        ...record.metadata
+      })),
+      documents: records.map(record => record.text)
+    };
+
+    const headers = {
+      'Content-Type': 'application/json'
+    };
+
+    if (this.apiKey) {
+      headers['Authorization'] = `Bearer ${this.apiKey}`;
+    }
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body)
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(`Failed to upsert embeddings into Chroma: ${response.status} ${errorBody}`);
+    }
+  }
+}
+
+class QdrantVectorDatabase extends AbstractVectorDatabase {
+  constructor(options = {}) {
+    super('qdrant');
+    this.url = options.url || process.env.VECTOR_DB_URL || 'http://localhost:6333';
+    this.collection = options.collection || process.env.VECTOR_DB_COLLECTION || 'mcp_metadata';
+    this.apiKey = options.apiKey || process.env.VECTOR_DB_API_KEY;
+  }
+
+  async upsertMany(records) {
+    const endpoint = new URL(`/collections/${this.collection}/points?wait=true`, this.url).toString();
+    const body = {
+      points: records.map(record => ({
+        id: record.id,
+        vector: record.embedding,
+        payload: {
+          source: record.source,
+          name: record.name,
+          description: record.description,
+          schema: record.schema,
+          example: record.example,
+          ...record.metadata
+        }
+      }))
+    };
+
+    const headers = {
+      'Content-Type': 'application/json'
+    };
+
+    if (this.apiKey) {
+      headers['api-key'] = this.apiKey;
+    }
+
+    const response = await fetch(endpoint, {
+      method: 'PUT',
+      headers,
+      body: JSON.stringify(body)
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(`Failed to upsert embeddings into Qdrant: ${response.status} ${errorBody}`);
+    }
+  }
+}
+
+class SupabaseVectorDatabase extends AbstractVectorDatabase {
+  constructor(options = {}) {
+    super('supabase');
+    this.url = options.url || process.env.VECTOR_DB_URL;
+    this.table = options.table || process.env.VECTOR_DB_TABLE || 'mcp_vectors';
+    this.apiKey = options.apiKey || process.env.VECTOR_DB_API_KEY;
+
+    if (!this.url) {
+      throw new Error('Supabase VECTOR_DB_URL is required');
+    }
+    if (!this.apiKey) {
+      throw new Error('Supabase VECTOR_DB_API_KEY is required');
+    }
+  }
+
+  async upsertMany(records) {
+    const endpoint = `${this.url.replace(/\/$/, '')}/${this.table}`;
+
+    const payload = records.map(record => ({
+      id: record.id,
+      source: record.source,
+      name: record.name,
+      description: record.description,
+      schema: record.schema ? JSON.stringify(record.schema) : null,
+      example: record.example,
+      text: record.text,
+      embedding: record.embedding,
+      metadata: record.metadata
+    }));
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'apikey': this.apiKey,
+        'Authorization': `Bearer ${this.apiKey}`,
+        'Prefer': 'resolution=merge-duplicates'
+      },
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(`Failed to upsert embeddings into Supabase: ${response.status} ${errorBody}`);
+    }
+  }
+}
+
+class VectorDatabaseFactory {
+  static create(options = {}) {
+    if (options.vectorDb) {
+      return options.vectorDb;
+    }
+
+    const provider = (options.vectorProvider || options.provider || process.env.VECTOR_DB_PROVIDER || 'memory').toLowerCase();
+
+    switch (provider) {
+      case 'chroma':
+        return new ChromaVectorDatabase(options);
+      case 'qdrant':
+        return new QdrantVectorDatabase(options);
+      case 'supabase':
+        return new SupabaseVectorDatabase(options);
+      case 'memory':
+      default:
+        return new MemoryVectorDatabase(options);
+    }
+  }
+}
+
+export class VectorStoreIngestor {
+  constructor(options = {}) {
+    loadClaudeEnv(options.envPath);
+    this.envPath = options.envPath;
+    const vectorOptions = {
+      vectorDb: options.vectorDb,
+      provider: options.vectorProvider || options.provider,
+      vectorProvider: options.vectorProvider || options.provider,
+      url: options.url || options.vectorUrl,
+      collection: options.collection || options.vectorCollection,
+      table: options.table || options.vectorTable,
+      apiKey: options.vectorApiKey || options.apiKey
+    };
+    const embeddingOptions = {
+      embeddingClient: options.embeddingClient,
+      embeddingProvider: options.embeddingProvider,
+      embeddingApiKey: options.embeddingApiKey,
+      embeddingModel: options.embeddingModel,
+      embeddingEndpoint: options.embeddingEndpoint
+    };
+
+    this.vectorDb = options.vectorDb || VectorDatabaseFactory.create(vectorOptions);
+    this.embeddingClient = options.embeddingClient || EmbeddingProviderFactory.create(embeddingOptions);
+  }
+
+  async collectRegistryDocuments() {
+    const registry = new MCPRegistry();
+    const docs = [];
+
+    for (const [id, info] of Object.entries(registry.getAll())) {
+      docs.push(normalizeDocument({
+        id: `registry:${id}`,
+        source: 'registry',
+        name: info.name || id,
+        description: info.description || '',
+        schema: {
+          package: info.package,
+          command: info.command,
+          args: info.args,
+          requiredEnv: info.requiredEnv,
+          categories: info.categories
+        },
+        example: info.command ? `${info.command} ${Array.isArray(info.args) ? info.args.join(' ') : ''}`.trim() : ''
+      }));
+    }
+
+    return docs;
+  }
+
+  async collectApiDatabaseDocuments() {
+    const docs = [];
+
+    for (const [id, api] of Object.entries(API_DATABASE)) {
+      docs.push(normalizeDocument({
+        id: `api-database:${id}`,
+        source: 'discovery:api-database',
+        name: api.name || id,
+        description: api.description || '',
+        schema: {
+          baseUrl: api.baseUrl,
+          auth: api.auth,
+          endpoints: api.endpoints,
+          documentation: api.documentation
+        },
+        example: api.endpoints?.[0]?.description || ''
+      }));
+    }
+
+    return docs;
+  }
+
+  async collectWebDiscoveryDocuments() {
+    const service = new WebSearchService();
+    const docs = [];
+    const combined = {
+      ...service.knownMaritimeAPIs,
+      ...service.marineWeatherAPIs
+    };
+
+    for (const [id, info] of Object.entries(combined)) {
+      docs.push(normalizeDocument({
+        id: `web-discovery:${id}`,
+        source: 'discovery:web-search',
+        name: info.name || id,
+        description: info.description || '',
+        schema: {
+          baseUrl: info.baseUrl,
+          auth: info.auth,
+          endpoints: info.endpoints,
+          documentation: info.documentation,
+          category: info.category
+        },
+        example: info.endpoints?.[0]?.description || ''
+      }));
+    }
+
+    return docs;
+  }
+
+  async collectToolDocuments() {
+    const docs = [];
+    const toolsPath = join(PROJECT_ROOT, 'mcp-tools.json');
+
+    if (!fs.existsSync(toolsPath)) {
+      return docs;
+    }
+
+    const raw = await readFile(toolsPath, 'utf8');
+    const json = JSON.parse(raw);
+    const exampleMap = new Map();
+
+    for (const example of json.examples || []) {
+      const tool = example.tool_calls?.[0]?.tool;
+      if (tool) {
+        exampleMap.set(tool, `${example.user} -> ${example.assistant}`);
+      }
+      docs.push(normalizeDocument({
+        id: `tool-example:${crypto.createHash('md5').update(JSON.stringify(example)).digest('hex')}`,
+        source: 'mcp-tools:example',
+        name: example.user,
+        description: example.assistant,
+        schema: example.tool_calls,
+        example: example.assistant
+      }));
+    }
+
+    for (const tool of json.tools || []) {
+      docs.push(normalizeDocument({
+        id: `tool:${tool.name}`,
+        source: 'mcp-tools:tool',
+        name: tool.name,
+        description: tool.description,
+        schema: tool.inputSchema,
+        example: exampleMap.get(tool.name) || ''
+      }));
+    }
+
+    return docs;
+  }
+
+  async collectDocuments() {
+    const [registryDocs, apiDocs, webDocs, toolDocs] = await Promise.all([
+      this.collectRegistryDocuments(),
+      this.collectApiDatabaseDocuments(),
+      this.collectWebDiscoveryDocuments(),
+      this.collectToolDocuments()
+    ]);
+
+    const docs = [...registryDocs, ...apiDocs, ...webDocs, ...toolDocs];
+
+    const seen = new Set();
+    return docs.filter(doc => {
+      if (seen.has(doc.id)) return false;
+      seen.add(doc.id);
+      return true;
+    });
+  }
+
+  async embedDocuments(documents) {
+    const embeddings = await this.embeddingClient.embed(documents.map(doc => doc.text));
+    return documents.map((doc, index) => ({
+      ...doc,
+      embedding: embeddings[index]
+    }));
+  }
+
+  async ingestAll() {
+    const documents = await this.collectDocuments();
+    if (documents.length === 0) {
+      return { count: 0, provider: this.vectorDb.provider };
+    }
+
+    const embedded = await this.embedDocuments(documents);
+    await this.vectorDb.upsertMany(embedded);
+
+    return {
+      count: embedded.length,
+      provider: this.vectorDb.provider,
+      ids: embedded.map(doc => doc.id)
+    };
+  }
+}
+
+export default VectorStoreIngestor;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "claude-mcp": "./bin/wtf-mcp.js"
   },
   "scripts": {
-    "test": "node test/test-mcp-server.js",
+    "test": "node test/test-mcp-server.js && node test/vector-store.test.js",
     "lint": "eslint lib/",
     "prepare": "npm run build",
     "build": "echo 'Build complete'",

--- a/test/vector-store.test.js
+++ b/test/vector-store.test.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+import assert from 'assert/strict';
+import chalk from 'chalk';
+import { VectorStoreIngestor, MemoryVectorDatabase, MockEmbeddingClient } from '../lib/router/vector-store.js';
+
+async function runVectorStoreTests() {
+  console.log(chalk.cyan('\n🧪 Testing vector store ingestion\n'));
+
+  const vectorDb = new MemoryVectorDatabase();
+  const embeddingClient = new MockEmbeddingClient();
+
+  const ingestor = new VectorStoreIngestor({
+    vectorDb,
+    embeddingClient,
+    provider: 'memory',
+    embeddingProvider: 'mock'
+  });
+
+  const result = await ingestor.ingestAll();
+
+  assert.ok(result.count > 0, 'ingestion should create at least one document');
+  assert.equal(result.provider, 'memory', 'provider should be memory for tests');
+  assert.equal(vectorDb.records.length, result.count, 'vector DB should receive all embedded records');
+  assert.ok(vectorDb.records.every(record => Array.isArray(record.embedding) && record.embedding.length > 0), 'records should include embeddings');
+  assert.ok(vectorDb.records.every(record => typeof record.text === 'string' && record.text.length > 0), 'records should include serialized text');
+
+  console.log(chalk.green(`✅ Ingestion succeeded with ${result.count} documents`));
+  console.log(chalk.gray(`Sample record: ${vectorDb.records[0].id}`));
+  console.log(chalk.cyan('\n🎯 Vector store ingestion tests completed!\n'));
+}
+
+runVectorStoreTests().catch((error) => {
+  console.error(chalk.red('❌ Vector store ingestion test failed:'), error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a vector store ingestion module that aggregates registry, discovery, and MCP tool metadata and persists it via pluggable vector databases
- expose a `wtf-mcp-manager ingest` CLI command for triggering embeddings with credentials loaded from `.claude/.env`
- document the required environment variables and add unit coverage for the ingestion flow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e17dc005988326a7ee7d17aebfedfd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced ingest CLI command to embed MCP metadata into a vector store.
  - Added support for multiple vector databases (Memory, Chroma, Qdrant, Supabase) and embedding providers via environment configuration.
  - CLI now reports ingestion count, provider, and sample IDs on success.

- Documentation
  - Expanded README with ingest workflow, configuration examples, required environment variables, and a Chroma example.
  - Updated command list in CLAUDE.md to include ingest.

- Tests
  - Added end-to-end ingestion test and updated test script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->