### PR TITLE
Add HTTP router service with Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1
+
+FROM node:20-alpine AS base
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+RUN npm install --omit=dev
+
+COPY . .
+
+ENV NODE_ENV=production \
+    ROUTER_HTTP_PORT=3000
+
+EXPOSE 3000
+
+CMD ["node", "lib/server/http.js"]

--- a/README.md
+++ b/README.md
@@ -86,6 +86,85 @@ npx wtf-mcp-manager doctor              # Diagnose issues
 
 ---
 
+## 🌐 Router HTTP Service & Docker Deployment
+
+The WTF router now ships with an optional HTTP interface that mirrors the retrieval capabilities of the in-process MCP server. This makes it easy to host the router next to a vector database and let both the CLI and the MCP instance talk to it over HTTP when available.
+
+### API Overview
+
+- **Endpoint:** `POST /router/query`
+- **Request body:**
+  ```json
+  {
+    "query": "database tools",
+    "limit": 8
+  }
+  ```
+- **Response:**
+  ```json
+  {
+    "results": [
+      { "id": "supabase", "name": "Supabase", "score": 12 },
+      { "id": "postgresql", "name": "PostgreSQL", "score": 9 }
+    ]
+  }
+  ```
+
+You can test the endpoint with curl once the service is running:
+
+```bash
+curl -X POST http://localhost:3000/router/query \
+  -H 'content-type: application/json' \
+  -d '{"query":"database", "limit":5}'
+```
+
+### CLI & MCP Integration
+
+- Set `WTF_MCP_ROUTER_URL` (or `ROUTER_HTTP_URL`) to the base URL of the HTTP service to make the CLI and MCP server prefer HTTP over stdio.
+- Fallback is automatic—if the HTTP call fails, the CLI/server falls back to the local registry search logic.
+- A new CLI helper command makes manual queries easy:
+
+  ```bash
+  npx wtf-mcp-manager router "vector database"
+  ```
+
+### Docker & Compose
+
+- `Dockerfile` runs the Node router service (`lib/server/http.js`).
+- `docker-compose.yml` launches both the router and a Qdrant vector database:
+
+  ```bash
+  docker compose up --build
+  ```
+
+- The router service exposes port `3000` by default and depends on `vector-db` (Qdrant) listening on `6333`.
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `WTF_MCP_ROUTER_URL` | _unset_ | Preferred HTTP endpoint for CLI/MCP clients. |
+| `ROUTER_HTTP_PORT` | `3000` | HTTP listen port for the router service. |
+| `ROUTER_HTTP_HOST` | `0.0.0.0` | Bind address for the HTTP server. |
+| `ROUTER_HTTP_CORS` | `*` | Comma-separated allow list for CORS responses. |
+| `ROUTER_VECTOR_URL` | `http://vector-db:6333` | Base URL for the vector database. |
+| `ROUTER_VECTOR_COLLECTION` | `wtf-mcp-router` | Qdrant collection name that stores router documents. |
+| `ROUTER_TOP_K` | `10` | Default number of results returned for queries. |
+| `ROUTER_HTTP_TIMEOUT` | `10000` | Timeout (ms) for vector DB requests. |
+| `ROUTER_EMBEDDINGS_URL` | _unset_ | Optional external embeddings endpoint for vector search. |
+| `ROUTER_EMBEDDINGS_API_KEY` | _unset_ | API key forwarded to the embeddings endpoint. |
+| `ROUTER_EMBEDDINGS_MODEL` | _unset_ | Model hint for the embeddings endpoint. |
+
+### Security Considerations
+
+- Restrict the router and vector database to private networks or VPNs; do not expose them directly to the public internet.
+- Configure `ROUTER_HTTP_CORS` and firewalls to allow only trusted origins and IP ranges.
+- Store secrets (embedding API keys, etc.) in `.env` or external secret managers—never commit them to git.
+- Enable TLS/HTTPS via a reverse proxy when the router is accessed across networks.
+- Apply access control to the vector database (Qdrant) and regularly rotate any API keys used for embeddings.
+
+---
+
 ## ✨ Intelligent Features
 
 ### 🧠 Smart MCP Discovery

--- a/bin/wtf-mcp.js
+++ b/bin/wtf-mcp.js
@@ -23,6 +23,55 @@ const packageJson = JSON.parse(await fs.readFile(join(__dirname, '..', 'package.
 const program = new Command();
 const manager = new MCPManager();
 
+const normalizeRouterEndpoint = (url) => {
+  if (!url) return null;
+  return url.endsWith('/') ? url.slice(0, -1) : url;
+};
+
+const getRouterEndpoint = () => {
+  return normalizeRouterEndpoint(
+    process.env.WTF_MCP_ROUTER_URL ||
+    process.env.ROUTER_HTTP_URL ||
+    process.env.ROUTER_URL ||
+    null
+  );
+};
+
+async function queryRouter(query, limit = 5) {
+  const endpoint = getRouterEndpoint();
+
+  if (endpoint) {
+    try {
+      const response = await fetch(`${endpoint}/router/query`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ query, limit })
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        if (Array.isArray(data.results) && data.results.length > 0) {
+          return data.results.slice(0, limit);
+        }
+      } else {
+        console.warn(chalk.yellow(`Router endpoint responded with status ${response.status}`));
+      }
+    } catch (error) {
+      console.warn(chalk.yellow(`Router HTTP query failed: ${error.message || error}`));
+    }
+  }
+
+  const { RouterRetriever } = await import('../lib/server/retriever.js');
+  const fallbackRetriever = new RouterRetriever({
+    registry: new MCPRegistry(),
+    vectorUrl: null,
+    embedUrl: null,
+    fallback: null
+  });
+
+  return fallbackRetriever.registryFallback(query, limit);
+}
+
 // Banner
 function showBanner() {
   console.log(chalk.cyan(`
@@ -141,6 +190,24 @@ program
       
       const registry = new MCPRegistry();
       const mcpInfo = registry.get(mcpId);
+
+      if (!mcpInfo) {
+        spinner.fail(chalk.red(`Unknown MCP: ${mcpId}`));
+        const suggestions = await queryRouter(mcpId, 5);
+
+        if (suggestions.length > 0) {
+          console.log(chalk.yellow('\nDid you mean:'));
+          suggestions.forEach((suggestion, index) => {
+            const label = suggestion.name || suggestion.id;
+            const description = suggestion.description ? ` - ${suggestion.description}` : '';
+            console.log(chalk.gray(`  ${index + 1}. ${label}${description}`));
+          });
+        } else {
+          console.log(chalk.gray('\nNo similar MCPs found in local registry.'));
+        }
+
+        process.exit(1);
+      }
       
       if (mcpInfo && mcpInfo.requiredEnv) {
         const missing = mcpInfo.requiredEnv.filter(key => !envVars[key] && !process.env[key]);
@@ -164,9 +231,46 @@ program
       
       await manager.enable(mcpId, envVars);
       spinner.succeed(chalk.green(`✅ ${mcpId} enabled! WTF that was easy!`));
-      
+
     } catch (error) {
       spinner.fail(chalk.red('WTF! Failed: ' + error.message));
+      process.exit(1);
+    }
+  });
+
+// Router command
+program
+  .command('router <query>')
+  .description('Query the WTF router for recommended MCPs')
+  .option('-k, --top <number>', 'Number of results to return', '5')
+  .action(async (query, options) => {
+    const limit = Number.parseInt(options.top, 10) || 5;
+    const spinner = ora(`Querying router for "${query}"...`).start();
+
+    try {
+      const results = await queryRouter(query, limit);
+      spinner.stop();
+
+      if (!results || results.length === 0) {
+        console.log(chalk.yellow('\nNo router recommendations found.'));
+        return;
+      }
+
+      console.log(chalk.cyan(`\n🔎 Router recommendations for "${query}":\n`));
+      results.forEach((result, index) => {
+        const label = result.name || result.id;
+        const score = typeof result.score === 'number' ? ` (score: ${result.score.toFixed(2)})` : '';
+        console.log(`${index + 1}. ${chalk.green(label)}${score}`);
+        if (result.description) {
+          console.log(chalk.gray(`   ${result.description}`));
+        }
+        if (Array.isArray(result.categories) && result.categories.length > 0) {
+          console.log(chalk.gray(`   Categories: ${result.categories.join(', ')}`));
+        }
+      });
+    } catch (error) {
+      spinner.fail(chalk.red('Failed to query router'));
+      console.error(chalk.red(error.message || error));
       process.exit(1);
     }
   });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.9'
+
+services:
+  router:
+    build: .
+    environment:
+      - NODE_ENV=production
+      - ROUTER_HTTP_PORT=3000
+      - ROUTER_VECTOR_URL=http://vector-db:6333
+      - ROUTER_VECTOR_COLLECTION=${ROUTER_VECTOR_COLLECTION:-wtf-mcp-router}
+      - ROUTER_TOP_K=${ROUTER_TOP_K:-8}
+      - ROUTER_EMBEDDINGS_URL=${ROUTER_EMBEDDINGS_URL:-}
+      - ROUTER_EMBEDDINGS_API_KEY=${ROUTER_EMBEDDINGS_API_KEY:-}
+      - ROUTER_EMBEDDINGS_MODEL=${ROUTER_EMBEDDINGS_MODEL:-}
+    ports:
+      - "3000:3000"
+    depends_on:
+      - vector-db
+
+  vector-db:
+    image: qdrant/qdrant:latest
+    ports:
+      - "6333:6333"
+    volumes:
+      - qdrant_storage:/qdrant/storage
+
+volumes:
+  qdrant_storage:

--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -15,6 +15,12 @@ import { MCPRegistry } from './registry.js';
 import { AutoDetector } from './detector.js';
 import { DynamicMCPGenerator } from './dynamic/mcp-generator.js';
 import { APIDiscoveryService } from './discovery/api-discovery.js';
+import { RouterRetriever } from './server/retriever.js';
+
+const normalizeRouterEndpoint = (url) => {
+  if (!url) return null;
+  return url.endsWith('/') ? url.slice(0, -1) : url;
+};
 
 class WTFMCPManagerServer {
   constructor() {
@@ -23,6 +29,13 @@ class WTFMCPManagerServer {
     this.detector = new AutoDetector();
     this.generator = new DynamicMCPGenerator();
     this.discovery = new APIDiscoveryService();
+    this.routerEndpoint = normalizeRouterEndpoint(
+      process.env.WTF_MCP_ROUTER_URL || process.env.ROUTER_HTTP_URL
+    );
+    this.routerRetriever = new RouterRetriever({
+      registry: this.registry,
+      fallback: (query, limit) => this.searchMCPsLocal(query, limit)
+    });
     this.availableMCPs = null;
     this.lastFetchTime = null;
     this.FETCH_CACHE_TTL = 30 * 60 * 1000; // 30 minutes
@@ -402,37 +415,56 @@ class WTFMCPManagerServer {
     }
   }
 
-  async searchMCPs(query) {
-    // If we have registry text, search within it
-    if (this.registryText) {
-      const queryLower = query.toLowerCase();
-      const lines = this.registryText.split('\n');
-      const results = [];
+  async queryRouterHTTP(query, limit = 10) {
+    if (!this.routerEndpoint) return null;
 
-      lines.forEach(line => {
-        if (line.toLowerCase().includes(queryLower)) {
-          // Extract package name from the line
-          const match = line.match(/@[\w-]+\/[\w-]+|[\w-]+-mcp|mcp-[\w-]+/);
-          if (match) {
-            results.push({
-              name: match[0],
-              description: line,
-              relevance: 'high',
-              source: 'registry'
-            });
-          }
-        }
+    try {
+      const response = await fetch(`${this.routerEndpoint}/router/query`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ query, limit })
       });
 
-      return results.slice(0, 10);
+      if (!response.ok) {
+        console.warn(`Router HTTP query failed with status ${response.status}`);
+        return null;
+      }
+
+      const data = await response.json();
+      if (Array.isArray(data.results)) {
+        return data.results.slice(0, limit);
+      }
+    } catch (error) {
+      console.warn('Router HTTP query error:', error.message || error);
     }
 
-    // Fallback to local registry
+    return null;
+  }
+
+  async searchMCPs(query) {
+    const limit = 10;
+    const httpResults = await this.queryRouterHTTP(query, limit);
+    if (httpResults && httpResults.length > 0) {
+      return httpResults;
+    }
+
     if (!this.availableMCPs) {
       this.availableMCPs = this.registry.getAll();
     }
 
-    const keywords = query.toLowerCase().split(/\s+/).filter(w => w.length > 2);
+    return await this.routerRetriever.query(query, {
+      limit,
+      registryText: this.registryText,
+      availableMCPs: this.availableMCPs
+    });
+  }
+
+  searchMCPsLocal(query, limit = 10) {
+    if (!this.availableMCPs) {
+      this.availableMCPs = this.registry.getAll();
+    }
+
+    const keywords = query.toLowerCase().split(/\s+/).filter(word => word.length > 2);
     const results = [];
 
     for (const [id, mcp] of Object.entries(this.availableMCPs)) {
@@ -442,16 +474,23 @@ class WTFMCPManagerServer {
         if (mcp.name && mcp.name.toLowerCase().includes(keyword)) score += 3;
         if (mcp.description && mcp.description.toLowerCase().includes(keyword)) score += 2;
         if (mcp.categories && Array.isArray(mcp.categories) &&
-            mcp.categories.some(cat => cat.includes(keyword))) score += 2;
+            mcp.categories.some(cat => cat.toLowerCase().includes(keyword))) score += 2;
         if (id.includes(keyword)) score += 1;
       });
 
       if (score > 0) {
-        results.push({ ...mcp, score });
+        results.push({
+          id,
+          name: mcp.name,
+          description: mcp.description,
+          categories: mcp.categories || [],
+          score,
+          source: 'registry'
+        });
       }
     }
 
-    return results.sort((a, b) => b.score - a.score).slice(0, 10);
+    return results.sort((a, b) => b.score - a.score).slice(0, limit);
   }
 
   async suggestMCPs(requirements) {

--- a/lib/server/http.js
+++ b/lib/server/http.js
@@ -1,0 +1,176 @@
+import http from 'http';
+import { fileURLToPath } from 'url';
+import { RouterRetriever } from './retriever.js';
+
+function resolvePort(portValue) {
+  if (!portValue) return 3000;
+  const parsed = parseInt(portValue, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 3000;
+}
+
+export class RouterHTTPServer {
+  constructor(options = {}) {
+    this.port = resolvePort(options.port || process.env.ROUTER_HTTP_PORT || process.env.PORT);
+    this.host = options.host || process.env.ROUTER_HTTP_HOST || '0.0.0.0';
+    this.corsOrigin = options.corsOrigin || process.env.ROUTER_HTTP_CORS || '*';
+    this.retriever = options.retriever || new RouterRetriever(options.retrieverOptions || {});
+    this.logger = options.logger || console;
+
+    this.server = http.createServer(this.handleRequest.bind(this));
+  }
+
+  async start() {
+    if (this.isListening) return;
+
+    await new Promise((resolve, reject) => {
+      this.server.once('error', reject);
+      this.server.listen(this.port, this.host, () => {
+        this.isListening = true;
+        this.logger.info?.(`🚀 WTF Router HTTP server listening on http://${this.host}:${this.port}`)
+          || console.log(`🚀 WTF Router HTTP server listening on http://${this.host}:${this.port}`);
+        resolve();
+      });
+    });
+  }
+
+  async stop() {
+    if (!this.isListening) return;
+
+    await new Promise((resolve, reject) => {
+      this.server.close(err => {
+        if (err) return reject(err);
+        this.isListening = false;
+        resolve();
+      });
+    });
+  }
+
+  async handleRequest(req, res) {
+    try {
+      if (this.handleCors(req, res)) {
+        return;
+      }
+
+      const url = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
+
+      if (req.method === 'GET' && url.pathname === '/health') {
+        return this.sendJSON(res, 200, { status: 'ok' });
+      }
+
+      if (req.method === 'POST' && url.pathname === '/router/query') {
+        const body = await this.parseBody(req);
+        const query = body?.query;
+        const options = {
+          limit: body?.limit || body?.topK,
+          filter: body?.filter,
+          metadata: body?.metadata
+        };
+
+        if (!query || typeof query !== 'string' || !query.trim()) {
+          return this.sendJSON(res, 400, { error: 'Query field is required' });
+        }
+
+        try {
+          const results = await this.retriever.query(query, options);
+          return this.sendJSON(res, 200, { results });
+        } catch (error) {
+          this.logger.error?.('Router retriever error:', error) || console.error('Router retriever error:', error);
+          return this.sendJSON(res, 500, { error: 'Router retrieval failed' });
+        }
+      }
+
+      return this.sendJSON(res, 404, { error: 'Not Found' });
+    } catch (error) {
+      this.logger.error?.('Router HTTP handler error:', error) || console.error('Router HTTP handler error:', error);
+      return this.sendJSON(res, 500, { error: 'Internal Server Error' });
+    }
+  }
+
+  handleCors(req, res) {
+    const originHeader = req.headers.origin;
+    const allowedOrigins = this.corsOrigin === '*'
+      ? ['*']
+      : String(this.corsOrigin)
+        .split(',')
+        .map(item => item.trim())
+        .filter(Boolean);
+
+    const allowOrigin = allowedOrigins.includes('*')
+      ? '*'
+      : (originHeader && allowedOrigins.includes(originHeader) ? originHeader : null);
+
+    if (allowOrigin) {
+      res.setHeader('Access-Control-Allow-Origin', allowOrigin);
+      res.setHeader('Vary', 'Origin');
+    }
+
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+
+    if (req.method === 'OPTIONS') {
+      res.statusCode = 204;
+      res.end();
+      return true;
+    }
+
+    return false;
+  }
+
+  async parseBody(req) {
+    return await new Promise((resolve, reject) => {
+      const chunks = [];
+
+      req.on('data', chunk => chunks.push(chunk));
+      req.on('end', () => {
+        if (chunks.length === 0) {
+          return resolve({});
+        }
+
+        try {
+          const raw = Buffer.concat(chunks).toString('utf-8');
+          if (!raw) return resolve({});
+          resolve(JSON.parse(raw));
+        } catch (error) {
+          reject(error);
+        }
+      });
+      req.on('error', reject);
+    });
+  }
+
+  sendJSON(res, statusCode, data) {
+    res.statusCode = statusCode;
+    res.setHeader('Content-Type', 'application/json');
+    if (!res.getHeader('Access-Control-Allow-Origin') && this.corsOrigin === '*') {
+      res.setHeader('Access-Control-Allow-Origin', '*');
+    }
+    res.end(JSON.stringify(data));
+  }
+}
+
+export async function createServer(options = {}) {
+  const server = new RouterHTTPServer(options);
+  await server.start();
+  return server;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const server = new RouterHTTPServer();
+  server.start().catch(error => {
+    console.error('Failed to start Router HTTP server:', error);
+    process.exit(1);
+  });
+
+  const shutdown = async () => {
+    try {
+      await server.stop();
+    } catch (error) {
+      console.error('Error shutting down Router HTTP server:', error);
+    } finally {
+      process.exit(0);
+    }
+  };
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+}

--- a/lib/server/retriever.js
+++ b/lib/server/retriever.js
@@ -1,0 +1,289 @@
+import { MCPRegistry } from '../registry.js';
+
+const DEFAULT_TOP_K = parseInt(process.env.ROUTER_TOP_K || '10', 10);
+const DEFAULT_TIMEOUT = parseInt(process.env.ROUTER_HTTP_TIMEOUT || '10000', 10);
+
+function normalizeBaseUrl(url) {
+  if (!url) return null;
+  return url.endsWith('/') ? url.slice(0, -1) : url;
+}
+
+function uniqueById(results = []) {
+  const seen = new Set();
+  return results.filter(result => {
+    const id = result?.id || result?.name;
+    if (!id || seen.has(id)) return false;
+    seen.add(id);
+    return true;
+  });
+}
+
+export class RouterRetriever {
+  constructor(options = {}) {
+    this.registry = options.registry || new MCPRegistry();
+    this.vectorUrl = options.vectorUrl || process.env.ROUTER_VECTOR_URL || process.env.VECTOR_DB_URL;
+    this.collection = options.collection || process.env.ROUTER_VECTOR_COLLECTION || 'wtf-mcp-router';
+    this.embedUrl = options.embedUrl || process.env.ROUTER_EMBEDDINGS_URL;
+    this.embedApiKey = options.embedApiKey || process.env.ROUTER_EMBEDDINGS_API_KEY;
+    this.embedModel = options.embedModel || process.env.ROUTER_EMBEDDINGS_MODEL;
+    this.topK = options.topK || DEFAULT_TOP_K;
+    this.timeoutMs = options.timeoutMs || DEFAULT_TIMEOUT;
+    this.logger = options.logger || console;
+    this.fallback = options.fallback || null;
+  }
+
+  async query(queryInput, options = {}) {
+    const query = typeof queryInput === 'string' ? queryInput : queryInput?.query || '';
+    if (!query || !query.trim()) {
+      throw new Error('Query text is required for router retrieval');
+    }
+
+    const limit = Math.max(1, options.limit || options.topK || queryInput?.limit || this.topK);
+    const registryText = options.registryText || queryInput?.registryText;
+    const availableMCPs = options.availableMCPs || queryInput?.availableMCPs;
+    const filter = options.filter || queryInput?.filter;
+    const metadata = options.metadata || queryInput?.metadata;
+
+    const vectorResults = await this.queryVectorDB(query, { limit, filter, metadata });
+    if (Array.isArray(vectorResults) && vectorResults.length > 0) {
+      return uniqueById(vectorResults).slice(0, limit);
+    }
+
+    const registryTextResults = this.searchRegistryText(query, registryText, limit);
+    if (registryTextResults.length > 0) {
+      return uniqueById(registryTextResults).slice(0, limit);
+    }
+
+    if (this.fallback) {
+      try {
+        const fallbackResults = await this.fallback(query, limit);
+        if (Array.isArray(fallbackResults) && fallbackResults.length > 0) {
+          return uniqueById(fallbackResults).slice(0, limit);
+        }
+      } catch (error) {
+        this.logger?.warn?.('Router fallback handler threw an error:', error);
+      }
+    }
+
+    return uniqueById(this.registryFallback(query, limit, availableMCPs));
+  }
+
+  async queryVectorDB(query, { limit, filter, metadata } = {}) {
+    if (!this.vectorUrl) return null;
+
+    const baseUrl = normalizeBaseUrl(this.vectorUrl);
+    if (!baseUrl) return null;
+
+    const embedding = await this.getEmbedding(query);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const endpointBase = `${baseUrl}/collections/${this.collection}/points`;
+      let url;
+      let body;
+
+      if (embedding && Array.isArray(embedding)) {
+        url = `${endpointBase}/search`;
+        body = {
+          vector: embedding,
+          top: limit,
+          with_payload: true,
+          filter
+        };
+      } else {
+        url = `${endpointBase}/scroll`;
+        body = {
+          filter: this.buildFullTextFilter(query, filter),
+          limit,
+          with_payload: true,
+          with_vectors: false
+        };
+      }
+
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+        signal: controller.signal
+      });
+
+      if (!response.ok) {
+        this.logger?.warn?.(`Router vector DB request failed: ${response.status} ${response.statusText}`);
+        return null;
+      }
+
+      const data = await response.json();
+      const points = Array.isArray(data.result) ? data.result : (data.points || []);
+
+      return points.map(point => this.formatVectorResult(point, metadata)).filter(Boolean);
+    } catch (error) {
+      if (error.name === 'AbortError') {
+        this.logger?.warn?.('Router vector DB request timed out');
+      } else {
+        this.logger?.warn?.('Router vector DB request error:', error);
+      }
+      return null;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  async getEmbedding(text) {
+    if (!this.embedUrl) return null;
+
+    try {
+      const headers = { 'content-type': 'application/json' };
+      if (this.embedApiKey) {
+        headers.Authorization = `Bearer ${this.embedApiKey}`;
+      }
+
+      const body = { input: text };
+      if (this.embedModel) {
+        body.model = this.embedModel;
+      }
+
+      const response = await fetch(this.embedUrl, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body)
+      });
+
+      if (!response.ok) {
+        this.logger?.warn?.(`Embedding request failed: ${response.status} ${response.statusText}`);
+        return null;
+      }
+
+      const data = await response.json();
+      return this.extractEmbedding(data);
+    } catch (error) {
+      this.logger?.warn?.('Embedding request error:', error);
+      return null;
+    }
+  }
+
+  extractEmbedding(data) {
+    if (!data) return null;
+
+    if (Array.isArray(data)) {
+      const item = data[0];
+      if (!item) return null;
+      if (Array.isArray(item)) return item;
+      if (Array.isArray(item.embedding)) return item.embedding;
+    }
+
+    if (Array.isArray(data.embedding)) {
+      return data.embedding;
+    }
+
+    if (Array.isArray(data.vector)) {
+      return data.vector;
+    }
+
+    if (Array.isArray(data.data) && data.data[0] && Array.isArray(data.data[0].embedding)) {
+      return data.data[0].embedding;
+    }
+
+    return null;
+  }
+
+  buildFullTextFilter(query, filter = {}) {
+    const filterClone = {
+      must: [...(filter.must || [])],
+      should: [...(filter.should || [])],
+      must_not: [...(filter.must_not || [])]
+    };
+
+    filterClone.must.push({ key: 'text', match: { text: query } });
+    return filterClone;
+  }
+
+  formatVectorResult(point, metadata = {}) {
+    if (!point) return null;
+
+    const payload = point.payload || {};
+    const id = payload.id || payload.mcpId || point.id;
+    const name = payload.name || payload.title || id;
+    const description = payload.description || payload.text || '';
+    const categories = payload.categories || payload.tags || [];
+    const source = payload.source || 'vector';
+    const score = typeof point.score === 'number' ? point.score : (payload.score || 0);
+
+    const result = {
+      id,
+      name,
+      description,
+      categories,
+      score,
+      source
+    };
+
+    if (metadata.includePayload !== false) {
+      result.payload = payload;
+    }
+
+    return result;
+  }
+
+  searchRegistryText(query, registryText, limit) {
+    if (!registryText) return [];
+
+    const queryLower = query.toLowerCase();
+    const lines = registryText.split('\n');
+    const results = [];
+
+    for (const line of lines) {
+      if (!line) continue;
+      if (line.toLowerCase().includes(queryLower)) {
+        const match = line.match(/@[\w-]+\/[\w-]+|[\w-]+-mcp|mcp-[\w-]+/);
+        if (match) {
+          results.push({
+            id: match[0],
+            name: match[0],
+            description: line.trim(),
+            score: 1,
+            source: 'registry-text'
+          });
+        }
+      }
+
+      if (results.length >= limit) break;
+    }
+
+    return results;
+  }
+
+  registryFallback(query, limit, availableMCPs) {
+    const keywords = query.toLowerCase().split(/\s+/).filter(word => word.length > 2);
+    if (keywords.length === 0) return [];
+
+    const mcps = availableMCPs || this.registry?.getAll?.() || {};
+    const results = [];
+
+    for (const [id, info] of Object.entries(mcps)) {
+      let score = 0;
+
+      for (const keyword of keywords) {
+        if (info.name && info.name.toLowerCase().includes(keyword)) score += 3;
+        if (info.description && info.description.toLowerCase().includes(keyword)) score += 2;
+        if (Array.isArray(info.categories) && info.categories.some(cat => cat.toLowerCase().includes(keyword))) score += 2;
+        if (id.includes(keyword)) score += 1;
+      }
+
+      if (score > 0) {
+        results.push({
+          id,
+          name: info.name || id,
+          description: info.description || '',
+          categories: info.categories || [],
+          score,
+          source: 'registry'
+        });
+      }
+    }
+
+    return results.sort((a, b) => b.score - a.score).slice(0, limit);
+  }
+}
+
+export default RouterRetriever;


### PR DESCRIPTION
## Summary
- add a router retriever module and expose it via a simple HTTP server with a /router/query endpoint
- update the CLI and MCP server to use the HTTP router when configured while preserving local fallbacks
- document the setup, environment variables, and provide Docker/Docker Compose definitions for the router stack

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e17cef188c8326af738002455762da

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced an HTTP Router service with health check and POST /router/query endpoint.
  - Added CLI command to query the router and display ranked MCP recommendations.
  - Enhanced enable flow with router-powered MCP suggestions and graceful fallbacks.

- Documentation
  - Updated README with Router HTTP API overview, curl examples, environment variables, and Docker/Compose deployment guidance and security notes.

- Chores
  - Simplified Docker image and compose setup; standardized to port 3000.
  - Updated environment configuration for router, vector DB, and embeddings services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->