### PR TITLE
Add vector-based tool retrieval and registry indexing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,10 +5,12 @@
 export { MCPManager } from './manager.js';
 export { MCPRegistry } from './registry.js';
 export { AutoDetector } from './detector.js';
+export { VectorRouter } from './router/vector-router.js';
 
 // Re-export for convenience
 export default {
   MCPManager,
   MCPRegistry,
-  AutoDetector
+  AutoDetector,
+  VectorRouter
 };

--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -10,14 +10,16 @@ import fs from 'fs/promises';
 import { join, resolve } from 'path';
 import path from 'path';
 import { homedir } from 'os';
+import { createHash } from 'crypto';
 import { MCPManager } from './manager.js';
 import { MCPRegistry } from './registry.js';
 import { AutoDetector } from './detector.js';
 import { DynamicMCPGenerator } from './dynamic/mcp-generator.js';
 import { APIDiscoveryService } from './discovery/api-discovery.js';
+import { VectorRouter } from './router/vector-router.js';
 
 class WTFMCPManagerServer {
-  constructor() {
+  constructor(options = {}) {
     this.manager = new MCPManager();
     this.registry = new MCPRegistry();
     this.detector = new AutoDetector();
@@ -28,6 +30,568 @@ class WTFMCPManagerServer {
     this.FETCH_CACHE_TTL = 30 * 60 * 1000; // 30 minutes
     this.dynamicMCPs = new Map();
     this.workflows = new Map();
+    this.vectorRouter = options.vectorRouter || new VectorRouter(options.vectorRouterOptions || {});
+    this.serverToolDefinitions = this.buildBaseToolDefinitions();
+    this.serverToolRecords = this.serverToolDefinitions.map(def => this.normalizeServerToolDefinition(def));
+    this.serverToolsIndexed = false;
+    this.registryToolRecords = [];
+    this.registryIndexHash = null;
+  }
+
+  buildBaseToolDefinitions() {
+    return [
+      {
+        name: 'analyze_environment',
+        description: 'Analyze global and project-level MCP configurations, detect conflicts and provide recommendations',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          additionalProperties: false
+        },
+        examples: [
+          {
+            name: 'Audit current MCP setup',
+            description: 'Review environment before enabling additional MCP servers',
+            arguments: {}
+          }
+        ]
+      },
+      {
+        name: 'fetch_mcps',
+        description: 'Fetch the latest available MCPs from the official registry. Takes 30 seconds on first run, then cached for 30 minutes.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            force: {
+              type: 'boolean',
+              description: 'Force refresh even if cached data is available'
+            }
+          },
+          additionalProperties: false
+        },
+        examples: [
+          {
+            name: 'Refresh registry',
+            description: 'Fetch fresh registry entries before searching for new tooling',
+            arguments: { force: true }
+          }
+        ]
+      },
+      {
+        name: 'list_mcps',
+        description: 'List all MCPs with their status (enabled/disabled)',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            enabled: {
+              type: 'boolean',
+              description: 'Show only enabled MCPs'
+            },
+            available: {
+              type: 'boolean',
+              description: 'Show only available (not enabled) MCPs'
+            }
+          },
+          additionalProperties: false
+        },
+        examples: []
+      },
+      {
+        name: 'enable_mcp',
+        description: 'Enable an MCP for the current project',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            mcpId: {
+              type: 'string',
+              description: "The ID of the MCP to enable (e.g., 'supabase', 'github')"
+            },
+            envVars: {
+              type: 'object',
+              description: 'Environment variables required by the MCP',
+              additionalProperties: {
+                type: 'string'
+              }
+            }
+          },
+          required: ['mcpId'],
+          additionalProperties: false
+        },
+        examples: [
+          {
+            name: 'Enable Supabase',
+            description: 'Provision Supabase MCP with required credentials',
+            arguments: {
+              mcpId: 'supabase',
+              envVars: {
+                SUPABASE_URL: '<project-url>',
+                SUPABASE_SERVICE_ROLE_KEY: '<secret>'
+              }
+            }
+          }
+        ]
+      },
+      {
+        name: 'search_mcps',
+        description: 'Search for MCPs based on keywords or requirements',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            query: {
+              type: 'string',
+              description: "Search query (e.g., 'database', 'web scraping', 'github')"
+            }
+          },
+          required: ['query'],
+          additionalProperties: false
+        },
+        examples: [
+          {
+            name: 'Find database tooling',
+            description: 'Locate MCPs capable of managing databases',
+            arguments: {
+              query: 'database management'
+            }
+          }
+        ]
+      },
+      {
+        name: 'retrieve_relevant_tools',
+        description: 'Retrieve the k most relevant MCP registry entries for a natural language query using the vector index.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            query: {
+              type: 'string',
+              description: 'Natural language description of the desired capability'
+            },
+            topK: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 50,
+              description: 'Number of results to return (default 5)'
+            },
+            categories: {
+              type: 'array',
+              description: 'Optional list of categories to filter results',
+              items: { type: 'string' }
+            }
+          },
+          required: ['query'],
+          additionalProperties: false
+        },
+        examples: [
+          {
+            name: 'Surface deployment tools',
+            description: 'Recommend MCPs for deployment automation tasks',
+            arguments: {
+              query: 'deploy web application to cloud',
+              topK: 3
+            }
+          }
+        ],
+        categories: ['registry', 'retrieval']
+      },
+      {
+        name: 'discover_or_create_mcp',
+        description: 'Discover APIs and optionally create MCPs from them automatically',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            query: {
+              type: 'string',
+              description: "Natural language description of what you need (e.g., 'weather data', 'stock prices')"
+            },
+            autoCreate: {
+              type: 'boolean',
+              description: 'Automatically create MCP for the best match'
+            }
+          },
+          required: ['query'],
+          additionalProperties: false
+        },
+        examples: []
+      },
+      {
+        name: 'generate_from_api',
+        description: 'Generate an MCP from an API specification',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            apiSpec: {
+              type: 'object',
+              description: 'API specification (OpenAPI, custom format, etc.)'
+            },
+            options: {
+              type: 'object',
+              properties: {
+                deploy: {
+                  type: 'boolean',
+                  description: 'Deploy the MCP immediately'
+                },
+                name: {
+                  type: 'string',
+                  description: 'Custom name for the MCP'
+                }
+              }
+            }
+          },
+          required: ['apiSpec'],
+          additionalProperties: false
+        },
+        examples: []
+      },
+      {
+        name: 'compose_workflow',
+        description: 'Compose multiple MCPs into a workflow',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            mcps: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'List of MCP IDs to include'
+            },
+            name: {
+              type: 'string',
+              description: 'Workflow name'
+            },
+            workflow: {
+              type: 'array',
+              description: 'Custom workflow steps (optional)'
+            }
+          },
+          required: ['mcps'],
+          additionalProperties: false
+        },
+        examples: []
+      },
+      {
+        name: 'test_mcp',
+        description: "Test an MCP to verify it's working correctly",
+        inputSchema: {
+          type: 'object',
+          properties: {
+            mcpId: {
+              type: 'string',
+              description: 'ID of the MCP to test'
+            },
+            tests: {
+              type: 'string',
+              description: "Test mode: 'auto', 'basic', 'full'",
+              default: 'auto'
+            }
+          },
+          required: ['mcpId'],
+          additionalProperties: false
+        },
+        examples: []
+      },
+      {
+        name: 'list_dynamic_mcps',
+        description: 'List all dynamically generated MCPs',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          additionalProperties: false
+        },
+        examples: []
+      }
+    ];
+  }
+
+  normalizeServerToolDefinition(tool) {
+    return {
+      id: `server_tool:${tool.name}`,
+      originalId: tool.name,
+      name: tool.name,
+      description: tool.description,
+      schema: tool.inputSchema,
+      examples: tool.examples || [],
+      categories: tool.categories || [],
+      type: 'server_tool',
+      source: 'wtf-mcp-manager'
+    };
+  }
+
+  async ensureServerToolsIndexed(force = false) {
+    if (!this.vectorRouter) {
+      return false;
+    }
+
+    if (this.serverToolsIndexed && !force) {
+      return true;
+    }
+
+    const success = await this.vectorRouter.upsertTools(this.serverToolRecords);
+    this.serverToolsIndexed = success;
+    return success;
+  }
+
+  ensureRegistryRecords() {
+    if (this.registryToolRecords.length > 0) {
+      return this.registryToolRecords;
+    }
+
+    const builtIn = this.registry.getAll();
+    const normalized = this.normalizeRegistryRecords(
+      Object.entries(builtIn).map(([id, info]) => ({ id, ...info, source: 'builtin' }))
+    );
+    this.registryToolRecords = normalized;
+    return normalized;
+  }
+
+  normalizeRegistryRecords(records = []) {
+    const list = Array.isArray(records) ? records : Object.values(records || {});
+    const normalized = [];
+    const seen = new Set();
+
+    for (const record of list) {
+      if (!record) {
+        continue;
+      }
+
+      const originalId = record.originalId || record.id || this.extractMCPId(record.package || record.name || '') || null;
+      if (!originalId || seen.has(originalId)) {
+        continue;
+      }
+
+      seen.add(originalId);
+
+      const name = record.name || this.formatMCPName(originalId);
+      const description = record.description || this.inferDescription(originalId);
+      const categories = Array.isArray(record.categories) && record.categories.length > 0
+        ? record.categories
+        : this.inferCategories(originalId);
+
+      const installCommand = record.command
+        ? [record.command, ...(record.args || [])].join(' ').trim()
+        : (record.package ? `npx ${record.package}` : null);
+
+      normalized.push({
+        id: `registry_mcp:${originalId}`,
+        originalId,
+        name,
+        description,
+        schema: record.schema || {
+          type: 'object',
+          properties: {
+            configuration: {
+              type: 'object',
+              description: 'Environment variables and configuration required by this MCP'
+            }
+          },
+          additionalProperties: true
+        },
+        examples: record.examples || this.buildDefaultRegistryExamples(originalId, installCommand),
+        categories,
+        type: 'registry_mcp',
+        source: record.source || 'registry',
+        package: record.package || null,
+        metadata: {
+          package: record.package || null,
+          command: record.command || null,
+          args: record.args || null
+        }
+      });
+    }
+
+    return normalized;
+  }
+
+  buildDefaultRegistryExamples(originalId, installCommand) {
+    const examples = [];
+
+    if (installCommand) {
+      examples.push({
+        name: 'Install MCP package',
+        description: `Install or invoke the ${originalId} MCP package`,
+        input: {
+          command: installCommand
+        }
+      });
+    }
+
+    examples.push({
+      name: 'Enable via manager',
+      description: `Enable ${originalId} using WTF-MCP-Manager`,
+      input: {
+        tool: 'enable_mcp',
+        arguments: {
+          mcpId: originalId
+        }
+      }
+    });
+
+    return examples;
+  }
+
+  fallbackRegistrySearch(query, limit, categories = []) {
+    let records = [...this.ensureRegistryRecords()];
+
+    if (Array.isArray(categories) && categories.length > 0) {
+      const categorySet = new Set(categories.map(cat => cat.toLowerCase()));
+      records = records.filter(record =>
+        (record.categories || []).some(cat => categorySet.has(cat.toLowerCase()))
+      );
+    }
+
+    if (!query) {
+      return records.slice(0, limit).map(record => this.projectRegistryRecord(record));
+    }
+
+    const keywords = query.toLowerCase().split(/\s+/).filter(Boolean);
+    const scored = records.map(record => {
+      const haystack = `${record.name} ${record.description} ${(record.categories || []).join(' ')} ${record.originalId}`.toLowerCase();
+      let score = 0;
+
+      for (const keyword of keywords) {
+        if (record.originalId.toLowerCase().includes(keyword)) {
+          score += 3;
+        }
+        if (haystack.includes(keyword)) {
+          score += 2;
+        }
+      }
+
+      return { record, score };
+    });
+
+    scored.sort((a, b) => b.score - a.score);
+    const positives = scored.filter(item => item.score > 0).slice(0, limit);
+
+    const takenIds = new Set(positives.map(item => item.record.id));
+    const remainder = records.filter(record => !takenIds.has(record.id));
+
+    while (positives.length < limit && remainder.length > 0) {
+      positives.push({ record: remainder.shift(), score: 0 });
+    }
+
+    return positives.slice(0, limit).map(item => this.projectRegistryRecord(item.record, item.score));
+  }
+
+  projectRegistryRecord(record, score = null) {
+    const tool = {
+      id: record.originalId,
+      name: record.name,
+      description: record.description,
+      categories: record.categories || [],
+      source: record.source,
+      package: record.package,
+      schema: record.schema,
+      examples: record.examples || []
+    };
+
+    if (score !== null && score !== undefined) {
+      tool.score = score;
+    }
+
+    return tool;
+  }
+
+  projectServerTool(record) {
+    const normalized = record && record.schema && record.originalId ? record : this.normalizeServerToolDefinition(record);
+    return {
+      name: normalized.originalId,
+      description: normalized.description,
+      inputSchema: normalized.schema,
+      examples: normalized.examples || []
+    };
+  }
+
+  fallbackServerToolSearch(query, limit) {
+    const q = query.toLowerCase();
+    const scored = this.serverToolDefinitions.map(tool => {
+      const haystack = `${tool.name} ${tool.description} ${JSON.stringify(tool.inputSchema)}`.toLowerCase();
+      let score = 0;
+
+      if (tool.name.toLowerCase().includes(q)) {
+        score += 3;
+      }
+
+      for (const keyword of q.split(/\s+/).filter(Boolean)) {
+        if (haystack.includes(keyword)) {
+          score += 1;
+        }
+      }
+
+      return { tool, score };
+    });
+
+    scored.sort((a, b) => b.score - a.score);
+    const positives = scored.filter(item => item.score > 0).slice(0, limit);
+    const taken = new Set(positives.map(item => item.tool.name));
+    const remainder = this.serverToolDefinitions.filter(tool => !taken.has(tool.name));
+
+    while (positives.length < limit && remainder.length > 0) {
+      positives.push({ tool: remainder.shift(), score: 0 });
+    }
+
+    return positives.slice(0, limit).map(item => this.projectServerTool(item.tool));
+  }
+
+  async getToolList(params = {}) {
+    const { query, topK, categories } = params;
+    const total = this.serverToolDefinitions.length;
+    const limit = Math.max(1, Math.min(Number.isFinite(Number(topK)) ? Number(topK) : total, total));
+
+    await this.ensureServerToolsIndexed();
+
+    if (!query) {
+      return this.serverToolDefinitions.map(tool => this.projectServerTool(tool));
+    }
+
+    const filter = { type: 'server_tool' };
+    if (Array.isArray(categories) && categories.length > 0) {
+      filter.categories = categories;
+    }
+
+    const hits = await this.vectorRouter.query(query, { topK: limit, filter });
+    if (Array.isArray(hits) && hits.length > 0) {
+      return hits.map(hit => this.projectServerTool(hit.payload));
+    }
+
+    return this.fallbackServerToolSearch(query, limit);
+  }
+
+  async retrieveRelevantTools(params = {}) {
+    const { query = '', topK = 5, categories = [] } = params;
+    const limit = Math.max(1, Math.min(Number.isFinite(Number(topK)) ? Number(topK) : 5, 50));
+
+    const records = this.ensureRegistryRecords();
+    if (records.length > 0 && !this.registryIndexHash) {
+      const indexed = await this.vectorRouter.upsertTools(records);
+      if (indexed) {
+        this.registryIndexHash = `bootstrap-${Date.now()}`;
+      }
+    }
+
+    let hits = null;
+    if (query) {
+      const filter = { type: 'registry_mcp' };
+      if (Array.isArray(categories) && categories.length > 0) {
+        filter.categories = categories;
+      }
+      hits = await this.vectorRouter.query(query, { topK: limit, filter });
+    }
+
+    if (Array.isArray(hits) && hits.length > 0) {
+      return {
+        query,
+        topK: limit,
+        tools: hits.map(hit => this.projectRegistryRecord(hit.payload, hit.score)),
+        fallback: false,
+        vectorStoreAvailable: this.vectorRouter?.available !== false
+      };
+    }
+
+    return {
+      query,
+      topK: limit,
+      tools: this.fallbackRegistrySearch(query, limit, categories),
+      fallback: true,
+      vectorStoreAvailable: this.vectorRouter?.available !== false
+    };
   }
 
   async initialize() {
@@ -131,7 +695,8 @@ class WTFMCPManagerServer {
         lastFetch: new Date(this.lastFetchTime).toISOString(),
         sourceSize: this.registryText.length,
         rawText: this.registryText,
-        message: "Using cached MCP registry (use force: true to refresh)"
+        message: "Using cached MCP registry (use force: true to refresh)",
+        indexedTools: this.registryToolRecords.length
       };
     }
 
@@ -146,9 +711,25 @@ class WTFMCPManagerServer {
       const text = await response.text();
       console.log(`📦 Fetched ${text.length} characters from registry`);
 
-      // Don't parse - just return the raw text for Claude to analyze
+      // Parse and index metadata while still returning the raw text for Claude to analyze
       this.lastFetchTime = now;
       this.registryText = text;
+
+      const parsedRegistry = this.parseMCPRegistry(text);
+      this.availableMCPs = parsedRegistry;
+      const normalizedRecords = this.normalizeRegistryRecords(Object.values(parsedRegistry));
+      this.registryToolRecords = normalizedRecords;
+
+      const dataHash = createHash('sha256').update(text).digest('hex');
+      const shouldIndex = force || this.registryIndexHash !== dataHash || this.vectorRouter.available === false;
+      let indexed = false;
+
+      if (shouldIndex && normalizedRecords.length > 0) {
+        indexed = await this.vectorRouter.upsertTools(normalizedRecords);
+        if (indexed) {
+          this.registryIndexHash = dataHash;
+        }
+      }
 
       return {
         success: true,
@@ -156,7 +737,12 @@ class WTFMCPManagerServer {
         lastFetch: new Date(this.lastFetchTime).toISOString(),
         sourceSize: text.length,
         rawText: text,
-        message: "Here's the full MCP registry. You can search through it to find relevant MCPs for the user's needs."
+        message: "Here's the full MCP registry. You can search through it to find relevant MCPs for the user's needs.",
+        indexedTools: normalizedRecords.length,
+        vectorIndex: {
+          attempted: shouldIndex,
+          success: indexed
+        }
       };
     } catch (error) {
       console.error('Failed to fetch MCP registry:', error.message);
@@ -164,13 +750,31 @@ class WTFMCPManagerServer {
       // Fallback to built-in registry
       this.availableMCPs = this.registry.getAll();
       this.lastFetchTime = now;
+      const normalizedRecords = this.normalizeRegistryRecords(
+        Object.entries(this.availableMCPs).map(([id, info]) => ({ id, ...info, source: 'builtin' }))
+      );
+      this.registryToolRecords = normalizedRecords;
+
+      const indexed = normalizedRecords.length > 0
+        ? await this.vectorRouter.upsertTools(normalizedRecords)
+        : false;
+      if (indexed) {
+        this.registryIndexHash = createHash('sha256')
+          .update(JSON.stringify(normalizedRecords.map(record => record.id)))
+          .digest('hex');
+      }
 
       return {
         mcps: this.availableMCPs,
         cached: false,
         fallback: true,
         error: error.message,
-        count: Object.keys(this.availableMCPs).length
+        count: Object.keys(this.availableMCPs).length,
+        indexedTools: normalizedRecords.length,
+        vectorIndex: {
+          attempted: normalizedRecords.length > 0,
+          success: indexed
+        }
       };
     }
   }
@@ -358,6 +962,9 @@ class WTFMCPManagerServer {
           // Fallback to basic search
           const searchResults = await this.searchMCPs(params.query || '');
           return searchResults;
+
+        case 'retrieve_relevant_tools':
+          return await this.retrieveRelevantTools(params);
 
         case 'diagnose':
           return await this.manager.diagnose();
@@ -865,190 +1472,12 @@ async function runMCPServer() {
             };
             console.log(JSON.stringify(initResponse));
           } else if (request.method === 'tools/list') {
+            const tools = await server.getToolList(request.params || {});
             const toolsResponse = {
               jsonrpc: "2.0",
               id: request.id,
               result: {
-                tools: [
-                  {
-                    name: "analyze_environment",
-                    description: "Analyze global and project-level MCP configurations, detect conflicts and provide recommendations",
-                    inputSchema: {
-                      type: "object",
-                      properties: {},
-                      additionalProperties: false
-                    }
-                  },
-                  {
-                    name: "fetch_mcps",
-                    description: "Fetch the latest available MCPs from the official registry. Takes 30 seconds on first run, then cached for 30 minutes.",
-                    inputSchema: {
-                      type: "object",
-                      properties: {
-                        force: {
-                          type: "boolean",
-                          description: "Force refresh even if cached data is available"
-                        }
-                      },
-                      additionalProperties: false
-                    }
-                  },
-                  {
-                    name: "list_mcps",
-                    description: "List all MCPs with their status (enabled/disabled)",
-                    inputSchema: {
-                      type: "object",
-                      properties: {
-                        enabled: {
-                          type: "boolean",
-                          description: "Show only enabled MCPs"
-                        },
-                        available: {
-                          type: "boolean",
-                          description: "Show only available (not enabled) MCPs"
-                        }
-                      },
-                      additionalProperties: false
-                    }
-                  },
-                  {
-                    name: "enable_mcp",
-                    description: "Enable an MCP for the current project",
-                    inputSchema: {
-                      type: "object",
-                      properties: {
-                        mcpId: {
-                          type: "string",
-                          description: "The ID of the MCP to enable (e.g., 'supabase', 'github')"
-                        },
-                        envVars: {
-                          type: "object",
-                          description: "Environment variables required by the MCP",
-                          additionalProperties: {
-                            type: "string"
-                          }
-                        }
-                      },
-                      required: ["mcpId"],
-                      additionalProperties: false
-                    }
-                  },
-                  {
-                    name: "search_mcps",
-                    description: "Search for MCPs based on keywords or requirements",
-                    inputSchema: {
-                      type: "object",
-                      properties: {
-                        query: {
-                          type: "string",
-                          description: "Search query (e.g., 'database', 'web scraping', 'github')"
-                        }
-                      },
-                      required: ["query"],
-                      additionalProperties: false
-                    }
-                  },
-                  {
-                    name: "discover_or_create_mcp",
-                    description: "Discover APIs and optionally create MCPs from them automatically",
-                    inputSchema: {
-                      type: "object",
-                      properties: {
-                        query: {
-                          type: "string",
-                          description: "Natural language description of what you need (e.g., 'weather data', 'stock prices')"
-                        },
-                        autoCreate: {
-                          type: "boolean",
-                          description: "Automatically create MCP for the best match"
-                        }
-                      },
-                      required: ["query"],
-                      additionalProperties: false
-                    }
-                  },
-                  {
-                    name: "generate_from_api",
-                    description: "Generate an MCP from an API specification",
-                    inputSchema: {
-                      type: "object",
-                      properties: {
-                        apiSpec: {
-                          type: "object",
-                          description: "API specification (OpenAPI, custom format, etc.)"
-                        },
-                        options: {
-                          type: "object",
-                          properties: {
-                            deploy: {
-                              type: "boolean",
-                              description: "Deploy the MCP immediately"
-                            },
-                            name: {
-                              type: "string",
-                              description: "Custom name for the MCP"
-                            }
-                          }
-                        }
-                      },
-                      required: ["apiSpec"],
-                      additionalProperties: false
-                    }
-                  },
-                  {
-                    name: "compose_workflow",
-                    description: "Compose multiple MCPs into a workflow",
-                    inputSchema: {
-                      type: "object",
-                      properties: {
-                        mcps: {
-                          type: "array",
-                          items: { type: "string" },
-                          description: "List of MCP IDs to include"
-                        },
-                        name: {
-                          type: "string",
-                          description: "Workflow name"
-                        },
-                        workflow: {
-                          type: "array",
-                          description: "Custom workflow steps (optional)"
-                        }
-                      },
-                      required: ["mcps"],
-                      additionalProperties: false
-                    }
-                  },
-                  {
-                    name: "test_mcp",
-                    description: "Test an MCP to verify it's working correctly",
-                    inputSchema: {
-                      type: "object",
-                      properties: {
-                        mcpId: {
-                          type: "string",
-                          description: "ID of the MCP to test"
-                        },
-                        tests: {
-                          type: "string",
-                          description: "Test mode: 'auto', 'basic', 'full'",
-                          default: "auto"
-                        }
-                      },
-                      required: ["mcpId"],
-                      additionalProperties: false
-                    }
-                  },
-                  {
-                    name: "list_dynamic_mcps",
-                    description: "List all dynamically generated MCPs",
-                    inputSchema: {
-                      type: "object",
-                      properties: {},
-                      additionalProperties: false
-                    }
-                  }
-                ]
+                tools
               }
             };
             console.log(JSON.stringify(toolsResponse));

--- a/lib/router/vector-router.js
+++ b/lib/router/vector-router.js
@@ -1,0 +1,232 @@
+import { createHash } from 'crypto';
+
+/**
+ * Simple vector router for MCP tool metadata backed by Qdrant.
+ * Uses a lightweight hashing-based embedding to avoid external dependencies.
+ */
+export class VectorRouter {
+  constructor(options = {}) {
+    this.baseUrl = options.baseUrl || process.env.QDRANT_URL || 'http://localhost:6333';
+    this.collection = options.collection || 'mcp_tools';
+    this.dimensions = options.dimensions || 384;
+    this.distance = options.distance || 'Cosine';
+    this.fetch = options.fetch || globalThis.fetch?.bind(globalThis);
+    this.logger = options.logger || console;
+    this.initialized = false;
+    this.available = true;
+    this.lastError = null;
+  }
+
+  async ensureCollection() {
+    if (!this.fetch) {
+      throw new Error('Fetch implementation required for VectorRouter');
+    }
+
+    if (this.initialized) {
+      return true;
+    }
+
+    const collectionUrl = `${this.baseUrl}/collections/${this.collection}`;
+
+    try {
+      const response = await this.fetch(collectionUrl);
+
+      if (response.ok) {
+        this.initialized = true;
+        this.available = true;
+        return true;
+      }
+
+      if (response.status === 404) {
+        const createResponse = await this.fetch(collectionUrl, {
+          method: 'PUT',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            vectors: {
+              size: this.dimensions,
+              distance: this.distance
+            }
+          })
+        });
+
+        if (!createResponse.ok) {
+          const message = await createResponse.text().catch(() => '');
+          throw new Error(`Failed to create vector collection: ${createResponse.status} ${message}`);
+        }
+
+        this.initialized = true;
+        this.available = true;
+        return true;
+      }
+
+      const message = await response.text().catch(() => '');
+      throw new Error(`Unexpected response from vector store: ${response.status} ${message}`);
+    } catch (error) {
+      this.available = false;
+      this.lastError = error;
+      throw error;
+    }
+  }
+
+  buildEmbeddingFromText(text = '') {
+    const normalized = text
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]/g, ' ')
+      .split(/\s+/)
+      .filter(Boolean);
+
+    if (normalized.length === 0) {
+      return new Array(this.dimensions).fill(0);
+    }
+
+    const vector = new Array(this.dimensions).fill(0);
+
+    for (const token of normalized) {
+      const digest = createHash('sha256').update(token).digest();
+      const index = digest.readUInt32BE(0) % this.dimensions;
+      const sign = (digest[4] & 1) === 0 ? 1 : -1;
+      vector[index] += sign;
+    }
+
+    const norm = Math.sqrt(vector.reduce((sum, value) => sum + value * value, 0)) || 1;
+    return vector.map(value => Number((value / norm).toFixed(6)));
+  }
+
+  stringifyRecord(record) {
+    const segments = [record.name || '', record.description || ''];
+
+    if (Array.isArray(record.categories) && record.categories.length > 0) {
+      segments.push(record.categories.join(' '));
+    }
+
+    if (record.schema) {
+      segments.push(JSON.stringify(record.schema));
+    }
+
+    if (Array.isArray(record.examples) && record.examples.length > 0) {
+      for (const example of record.examples) {
+        segments.push(typeof example === 'string' ? example : JSON.stringify(example));
+      }
+    }
+
+    if (record.metadata) {
+      segments.push(JSON.stringify(record.metadata));
+    }
+
+    return segments.join('\n');
+  }
+
+  async upsertTools(records = []) {
+    if (!Array.isArray(records) || records.length === 0) {
+      return false;
+    }
+
+    try {
+      await this.ensureCollection();
+
+      const points = records.map(record => ({
+        id: record.id,
+        vector: this.buildEmbeddingFromText(this.stringifyRecord(record)),
+        payload: {
+          record,
+          type: record.type,
+          name: record.name,
+          categories: record.categories || [],
+          source: record.source || null
+        }
+      }));
+
+      const response = await this.fetch(`${this.baseUrl}/collections/${this.collection}/points`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ points })
+      });
+
+      if (!response.ok) {
+        const message = await response.text().catch(() => '');
+        throw new Error(`Failed to upsert points: ${response.status} ${message}`);
+      }
+
+      this.available = true;
+      return true;
+    } catch (error) {
+      this.available = false;
+      this.lastError = error;
+      if (this.logger && typeof this.logger.warn === 'function') {
+        this.logger.warn(`[VectorRouter] ${error.message}`);
+      }
+      return false;
+    }
+  }
+
+  buildFilter(filter) {
+    if (!filter) {
+      return undefined;
+    }
+
+    const must = [];
+
+    if (filter.type) {
+      must.push({ key: 'type', match: { value: filter.type } });
+    }
+
+    if (Array.isArray(filter.categories) && filter.categories.length > 0) {
+      must.push({ key: 'categories', match: { any: filter.categories } });
+    }
+
+    if (filter.source) {
+      must.push({ key: 'source', match: { value: filter.source } });
+    }
+
+    return must.length > 0 ? { must } : undefined;
+  }
+
+  async query(query, { topK = 5, filter } = {}) {
+    if (!query || !query.trim()) {
+      return [];
+    }
+
+    try {
+      await this.ensureCollection();
+
+      const body = {
+        vector: this.buildEmbeddingFromText(query),
+        limit: topK,
+        with_payload: true
+      };
+
+      const qdrantFilter = this.buildFilter(filter);
+      if (qdrantFilter) {
+        body.filter = qdrantFilter;
+      }
+
+      const response = await this.fetch(`${this.baseUrl}/collections/${this.collection}/points/search`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body)
+      });
+
+      if (!response.ok) {
+        const message = await response.text().catch(() => '');
+        throw new Error(`Vector search failed: ${response.status} ${message}`);
+      }
+
+      const data = await response.json();
+      const hits = Array.isArray(data?.result) ? data.result : [];
+
+      this.available = true;
+      return hits.map(hit => ({
+        id: hit.id,
+        score: hit.score,
+        payload: hit.payload?.record || hit.payload || null
+      }));
+    } catch (error) {
+      this.available = false;
+      this.lastError = error;
+      if (this.logger && typeof this.logger.warn === 'function') {
+        this.logger.warn(`[VectorRouter] ${error.message}`);
+      }
+      return null;
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "claude-mcp": "./bin/wtf-mcp.js"
   },
   "scripts": {
-    "test": "node test/test-mcp-server.js",
+    "test": "node --test test/*.test.js && node test/test-mcp-server.js",
     "lint": "eslint lib/",
     "prepare": "npm run build",
     "build": "echo 'Build complete'",

--- a/test/vector-router.test.js
+++ b/test/vector-router.test.js
@@ -1,0 +1,166 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { VectorRouter } from '../lib/router/vector-router.js';
+import { WTFMCPManagerServer } from '../lib/mcp-server.js';
+
+const noopLogger = { warn: () => {} };
+
+const createResponse = (body, options = {}) => {
+  const init = { status: 200, headers: { 'content-type': 'application/json' }, ...options };
+  if (body === null || body === undefined) {
+    return new Response(null, init);
+  }
+  const payload = typeof body === 'string' ? body : JSON.stringify(body);
+  return new Response(payload, init);
+};
+
+test('VectorRouter creates collection and upserts tool metadata', async () => {
+  const calls = [];
+  const fetchMock = async (url, options = {}) => {
+    calls.push({ url, options });
+
+    if (url === 'http://qdrant.local/collections/test-tools') {
+      if (!options.method) {
+        return createResponse(null, { status: 404 });
+      }
+      return createResponse({ result: 'created' });
+    }
+
+    if (url === 'http://qdrant.local/collections/test-tools/points') {
+      return createResponse({ result: { upserted: 1 } });
+    }
+
+    throw new Error(`Unexpected request: ${url}`);
+  };
+
+  const router = new VectorRouter({
+    baseUrl: 'http://qdrant.local',
+    collection: 'test-tools',
+    dimensions: 8,
+    fetch: fetchMock,
+    logger: noopLogger
+  });
+
+  const record = {
+    id: 'registry_mcp:github',
+    originalId: 'github',
+    name: 'GitHub',
+    description: 'Code hosting and collaboration',
+    schema: { type: 'object' },
+    examples: [],
+    categories: ['development'],
+    type: 'registry_mcp',
+    source: 'builtin'
+  };
+
+  const success = await router.upsertTools([record]);
+  assert.strictEqual(success, true);
+  assert.strictEqual(calls.length, 3, 'should call collection get, create, and upsert');
+
+  const upsertCall = calls[calls.length - 1];
+  const payload = JSON.parse(upsertCall.options.body);
+  assert.strictEqual(payload.points[0].id, record.id);
+  assert.strictEqual(payload.points[0].vector.length, 8);
+});
+
+test('VectorRouter search applies filters and returns payloads', async () => {
+  const requests = [];
+  const fetchMock = async (url, options = {}) => {
+    if (url === 'http://qdrant.local/collections/test-tools') {
+      return createResponse({ result: {} });
+    }
+
+    if (url === 'http://qdrant.local/collections/test-tools/points/search') {
+      const body = JSON.parse(options.body);
+      requests.push(body);
+      return createResponse({
+        result: [
+          {
+            id: 'registry_mcp:database',
+            score: 0.9,
+            payload: {
+              record: {
+                id: 'registry_mcp:database',
+                originalId: 'database',
+                name: 'Database MCP',
+                description: 'Manage relational databases',
+                schema: { type: 'object' },
+                examples: [],
+                categories: ['database'],
+                type: 'registry_mcp',
+                source: 'registry'
+              }
+            }
+          },
+          {
+            id: 'registry_mcp:warehouse',
+            score: 0.72,
+            payload: {
+              record: {
+                id: 'registry_mcp:warehouse',
+                originalId: 'warehouse',
+                name: 'Warehouse MCP',
+                description: 'Data warehouse tooling',
+                schema: { type: 'object' },
+                examples: [],
+                categories: ['database'],
+                type: 'registry_mcp',
+                source: 'registry'
+              }
+            }
+          }
+        ]
+      });
+    }
+
+    throw new Error(`Unexpected request: ${url}`);
+  };
+
+  const router = new VectorRouter({
+    baseUrl: 'http://qdrant.local',
+    collection: 'test-tools',
+    dimensions: 8,
+    fetch: fetchMock,
+    logger: noopLogger
+  });
+
+  const results = await router.query('warehouse database operations', {
+    topK: 2,
+    filter: { type: 'registry_mcp', categories: ['database'] }
+  });
+
+  assert.ok(Array.isArray(results));
+  assert.strictEqual(results.length, 2);
+  assert.strictEqual(results[0].payload.name, 'Database MCP');
+  assert.deepStrictEqual(requests[0].filter, {
+    must: [
+      { key: 'type', match: { value: 'registry_mcp' } },
+      { key: 'categories', match: { any: ['database'] } }
+    ]
+  });
+});
+
+test('retrieveRelevantTools falls back when vector search is unavailable', async () => {
+  class UnavailableVectorRouter {
+    constructor() {
+      this.available = false;
+    }
+
+    async upsertTools() {
+      return false;
+    }
+
+    async query() {
+      this.available = false;
+      return null;
+    }
+  }
+
+  const server = new WTFMCPManagerServer({ vectorRouter: new UnavailableVectorRouter() });
+  const result = await server.retrieveRelevantTools({ query: 'database services', topK: 3 });
+
+  assert.ok(result.fallback, 'should fall back when vector store is unavailable');
+  assert.ok(result.tools.length > 0, 'fallback should still provide results');
+  assert.strictEqual(result.vectorStoreAvailable, false);
+  assert.ok(result.tools.every(tool => tool.name && tool.description));
+});


### PR DESCRIPTION
## Summary
- add a VectorRouter module that manages Qdrant-backed embeddings for tool metadata
- index server tool definitions and registry entries, expose a retrieve_relevant_tools endpoint, and allow tools/list filtering via the shared helper
- add unit tests that cover ingestion, search filtering, and vector fallback and run them via the npm test script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e17ce623588326b2d6ea8f45569e57