### PR TITLE
Add HTTP router service and Docker deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+COPY . .
+
+ENV NODE_ENV=production \
+    ROUTER_PORT=3333
+
+EXPOSE 3333
+
+CMD ["node", "lib/server/http.js"]

--- a/README.md
+++ b/README.md
@@ -86,6 +86,81 @@ npx wtf-mcp-manager doctor              # Diagnose issues
 
 ---
 
+## 🛰 Router & Vector Retrieval Service
+
+The MCP manager now ships with an optional HTTP router that fronts a vector database. The CLI (`wtf-mcp-manager`) and the MCP tools will automatically call this service whenever `MCP_ROUTER_URL` is configured. If the router cannot be reached the manager gracefully falls back to the local search heuristics, so offline usage continues to work.
+
+### Quick start
+
+```bash
+# Start the router against a locally running vector DB
+npm run router
+
+# Or launch the full stack (router + Qdrant) with Docker
+docker compose up --build
+```
+
+The router exposes the following endpoints:
+
+| Endpoint | Description |
+|----------|-------------|
+| `POST /router/query` | Query the vector retriever. Body: `{ query, topK?, filter?, scoreThreshold? }`. |
+| `POST /router/upsert` | Ingest or update documents. Body: `{ documents: [{ id, text, metadata, ... }] }`. |
+| `POST /router/delete` | Remove vectors by id. Body: `{ ids: string[] }`. |
+| `GET /health` | Readiness and vector DB diagnostics. |
+
+When `ROUTER_API_KEY` is set the router requires callers to send the matching value in the `x-api-key` header. The client automatically includes `MCP_ROUTER_API_KEY` (or `ROUTER_API_KEY`) when available.
+
+### Environment variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `ROUTER_PORT` | `3333` | TCP port for the HTTP wrapper. |
+| `ROUTER_HOST` | `0.0.0.0` | Bind address for the router. |
+| `VECTOR_DB_URL` | `http://localhost:6333` | Qdrant (or compatible) base URL. |
+| `VECTOR_DB_COLLECTION` | `wtf-mcp-router` | Collection name for stored MCP vectors. |
+| `VECTOR_BOOTSTRAP` | `true` | Seed the vector store from the built-in registry on start. |
+| `VECTOR_BOOTSTRAP_FORCE` | `false` | Force a fresh bootstrap even when vectors exist. |
+| `ROUTER_API_KEY` | unset | Require `x-api-key` authentication for HTTP requests. |
+| `MCP_ROUTER_URL` | unset | CLI and MCP server will use the router when provided. |
+| `MCP_ROUTER_API_KEY` | unset | API key sent by clients when calling the router. |
+
+### Docker Compose deployment
+
+The included `docker-compose.yml` spins up the router alongside a Qdrant vector database. The router image is built from the local source (`Dockerfile`) and automatically bootstraps the MCP registry into Qdrant. To launch the stack:
+
+```bash
+docker compose up --build
+```
+
+Persisted data lives in the `qdrant_data` volume. Override environment variables via a `.env` file (for example to set `ROUTER_API_KEY` or change the exposed ports).
+
+### Security notes
+
+- Always set `ROUTER_API_KEY` (and `MCP_ROUTER_API_KEY` for clients) before exposing the router outside of localhost. The server rejects unauthenticated traffic when the key is present.
+- Run Qdrant and the router on a private network or behind a reverse proxy that terminates TLS. The vector DB should never be reachable directly from the public internet.
+- Store secrets in `.env` files or secret managers rather than committing them to git. The CLI automatically respects environment variables at runtime.
+- Consider restricting Docker network access (`docker compose --profile internal` or a custom network) if you deploy alongside other infrastructure.
+
+### Local profiling
+
+Use the bundled scripts to profile performance hotspots:
+
+```bash
+# Generate a V8 CPU profile for the router
+npm run profile:router
+
+# Inspect the resulting isolate file
+node --prof-process isolate-*.log
+
+# For live debugging, start with the inspector enabled
+NODE_OPTIONS="--inspect" npm run router
+```
+
+These commands work both on bare metal and inside the Docker container (`docker compose run --service-ports router npm run profile:router`).
+
+---
+
 ## ✨ Intelligent Features
 
 ### 🧠 Smart MCP Discovery

--- a/bin/wtf-mcp.js
+++ b/bin/wtf-mcp.js
@@ -15,6 +15,7 @@ import fs from 'fs/promises';
 import { MCPManager } from '../lib/manager.js';
 import { MCPRegistry } from '../lib/registry.js';
 import { AutoDetector } from '../lib/detector.js';
+import { RouterClient } from '../lib/router/client.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -22,6 +23,7 @@ const packageJson = JSON.parse(await fs.readFile(join(__dirname, '..', 'package.
 
 const program = new Command();
 const manager = new MCPManager();
+const routerClient = new RouterClient();
 
 // Banner
 function showBanner() {
@@ -116,6 +118,54 @@ program
     }
     
     console.log(chalk.yellow('\n✅ = Enabled | ❌ = WTF not enabled yet\n'));
+  });
+
+// Search command (uses router when available)
+program
+  .command('search <query>')
+  .description('Search for MCPs that match your query')
+  .option('-k, --top <number>', 'Number of matches to display', '8')
+  .action(async (query, options) => {
+    const top = Math.max(1, parseInt(options.top, 10) || 8);
+
+    let results = [];
+    let usedRouter = false;
+
+    if (routerClient.isConfigured) {
+      try {
+        results = await routerClient.query({ query, topK: top }) || [];
+        usedRouter = Array.isArray(results) && results.length > 0;
+      } catch (error) {
+        console.log(chalk.yellow(`⚠️  Router search failed (${error.message}). Falling back to local registry.`));
+        results = [];
+      }
+    }
+
+    if (!results || results.length === 0) {
+      const fallbackRegistry = new MCPRegistry();
+      results = fallbackRegistry.search(query).slice(0, top);
+    }
+
+    if (results.length === 0) {
+      console.log(chalk.yellow(`No MCPs found for "${query}"`));
+      return;
+    }
+
+    console.log(chalk.cyan(`\n🔍 Results for "${query}":${usedRouter ? ' (via router)' : ''}\n`));
+    results.forEach((mcp, index) => {
+      const name = mcp.name || mcp.id;
+      const description = mcp.description || '';
+      const score = typeof mcp.score === 'number' ? ` (score: ${mcp.score.toFixed(3)})` : '';
+      console.log(`${String(index + 1).padStart(2, '0')}. ${chalk.green(name)}${score}`);
+      if (description) {
+        console.log(chalk.gray(`    ${description}`));
+      }
+      if (mcp.categories && mcp.categories.length) {
+        console.log(chalk.gray(`    Categories: ${mcp.categories.join(', ')}`));
+      }
+    });
+
+    console.log('');
   });
 
 // Enable command

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+version: '3.9'
+
+services:
+  router:
+    build: .
+    environment:
+      NODE_ENV: production
+      ROUTER_PORT: 3333
+      VECTOR_DB_URL: http://vector-db:6333
+      VECTOR_DB_COLLECTION: wtf-mcp-router
+      VECTOR_BOOTSTRAP: "true"
+      ROUTER_API_KEY: ${ROUTER_API_KEY:-}
+    ports:
+      - "3333:3333"
+    depends_on:
+      vector-db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://localhost:3333/health').then(r=>{if(!r.ok)process.exit(1);})"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
+
+  vector-db:
+    image: qdrant/qdrant:latest
+    ports:
+      - "6333:6333"
+    volumes:
+      - qdrant_data:/qdrant/storage
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:6333/healthz"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 10s
+
+volumes:
+  qdrant_data:

--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -15,6 +15,7 @@ import { MCPRegistry } from './registry.js';
 import { AutoDetector } from './detector.js';
 import { DynamicMCPGenerator } from './dynamic/mcp-generator.js';
 import { APIDiscoveryService } from './discovery/api-discovery.js';
+import { RouterClient } from './router/client.js';
 
 class WTFMCPManagerServer {
   constructor() {
@@ -28,6 +29,7 @@ class WTFMCPManagerServer {
     this.FETCH_CACHE_TTL = 30 * 60 * 1000; // 30 minutes
     this.dynamicMCPs = new Map();
     this.workflows = new Map();
+    this.routerClient = new RouterClient();
   }
 
   async initialize() {
@@ -403,6 +405,13 @@ class WTFMCPManagerServer {
   }
 
   async searchMCPs(query) {
+    if (this.routerClient?.isConfigured) {
+      const remoteResults = await this.routerClient.query({ query, topK: 10 });
+      if (Array.isArray(remoteResults) && remoteResults.length > 0) {
+        return remoteResults;
+      }
+    }
+
     // If we have registry text, search within it
     if (this.registryText) {
       const queryLower = query.toLowerCase();

--- a/lib/router/client.js
+++ b/lib/router/client.js
@@ -1,0 +1,113 @@
+/**
+ * Lightweight client for the MCP router HTTP service.
+ * Provides automatic fallback and cooldown when the remote
+ * service is unavailable.
+ */
+
+import fetch from 'node-fetch';
+
+const DEFAULT_BASE_URL = process.env.MCP_ROUTER_URL || process.env.ROUTER_URL || null;
+
+export class RouterClient {
+  constructor(options = {}) {
+    this.baseUrl = (options.baseUrl || DEFAULT_BASE_URL || '').replace(/\/$/, '');
+    this.timeoutMs = options.timeoutMs || 2000;
+    this.cooldownMs = options.cooldownMs || 15000;
+    this.apiKey = options.apiKey || process.env.MCP_ROUTER_API_KEY || process.env.ROUTER_API_KEY || null;
+    this.disabledUntil = 0;
+  }
+
+  get isConfigured() {
+    return Boolean(this.baseUrl);
+  }
+
+  async fetchJson(path, { method = 'GET', body, headers = {} } = {}) {
+    if (!this.isConfigured) {
+      return null;
+    }
+
+    const now = Date.now();
+    if (now < this.disabledUntil) {
+      return null;
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const response = await fetch(`${this.baseUrl}${path}`, {
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+          ...(this.apiKey ? { 'x-api-key': this.apiKey } : {}),
+          ...headers
+        },
+        body,
+        signal: controller.signal
+      });
+
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(`Router request failed: ${response.status} ${response.statusText} ${text}`.trim());
+      }
+
+      if (response.status === 204) {
+        return null;
+      }
+
+      const contentType = response.headers.get('content-type');
+      if (contentType && contentType.includes('application/json')) {
+        return await response.json();
+      }
+
+      return await response.text();
+    } catch (error) {
+      this.disabledUntil = Date.now() + this.cooldownMs;
+      if (error.name === 'AbortError') {
+        throw new Error('Router request timed out');
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  async query({ query, topK = 10, filter = null, scoreThreshold = null } = {}) {
+    try {
+      const response = await this.fetchJson('/router/query', {
+        method: 'POST',
+        body: JSON.stringify({ query, topK, filter, scoreThreshold })
+      });
+
+      return response?.results || null;
+    } catch (error) {
+      // Silence errors - consumers will fall back to local search
+      return null;
+    }
+  }
+
+  async upsert(documents = []) {
+    return this.fetchJson('/router/upsert', {
+      method: 'POST',
+      body: JSON.stringify({ documents })
+    });
+  }
+
+  async delete(ids = []) {
+    return this.fetchJson('/router/delete', {
+      method: 'POST',
+      body: JSON.stringify({ ids })
+    });
+  }
+
+  async health() {
+    try {
+      const response = await this.fetchJson('/health');
+      return response;
+    } catch (error) {
+      return { status: 'error', error: error.message };
+    }
+  }
+}
+
+export default RouterClient;

--- a/lib/router/vector-retriever.js
+++ b/lib/router/vector-retriever.js
@@ -1,0 +1,571 @@
+#!/usr/bin/env node
+/**
+ * Vector retriever for the WTF MCP router.
+ * Provides utilities for embedding MCP metadata and
+ * storing/searching vectors inside a Qdrant-compatible database.
+ */
+
+import fetch from 'node-fetch';
+
+const DEFAULT_DIMENSIONS = 512;
+const DEFAULT_COLLECTION = 'wtf-mcp-router';
+
+export class VectorRetriever {
+  constructor(options = {}) {
+    this.vectorDbUrl = (options.vectorDbUrl || process.env.VECTOR_DB_URL || 'http://localhost:6333').replace(/\/$/, '');
+    this.collection = options.collection || process.env.VECTOR_DB_COLLECTION || DEFAULT_COLLECTION;
+    this.dimensions = options.dimensions || DEFAULT_DIMENSIONS;
+    this.timeoutMs = options.timeoutMs || 5000;
+    this.registry = options.registry;
+    this.ready = false;
+  }
+
+  /**
+   * Basic deterministic string hash. Adapted from Java's String.hashCode.
+   */
+  hashToken(token) {
+    let hash = 0;
+    for (let i = 0; i < token.length; i++) {
+      hash = ((hash << 5) - hash) + token.charCodeAt(i);
+      hash |= 0; // Convert to 32bit integer
+    }
+    return hash;
+  }
+
+  /**
+   * Convert text into a fixed-size vector using hashed bag-of-words.
+   */
+  embedText(text) {
+    const tokens = (text || '')
+      .toLowerCase()
+      .split(/[^a-z0-9]+/i)
+      .filter(Boolean);
+
+    if (tokens.length === 0) {
+      return new Array(this.dimensions).fill(0);
+    }
+
+    const vector = new Array(this.dimensions).fill(0);
+
+    tokens.forEach(token => {
+      const index = Math.abs(this.hashToken(token)) % this.dimensions;
+      vector[index] += 1;
+    });
+
+    // Normalize to unit length to make cosine similarity meaningful
+    const norm = Math.sqrt(vector.reduce((acc, value) => acc + (value * value), 0));
+    if (norm === 0) {
+      return vector;
+    }
+
+    return vector.map(value => value / norm);
+  }
+
+  async fetchJson(path, { method = 'GET', body, headers = {} } = {}) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const response = await fetch(`${this.vectorDbUrl}${path}`, {
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+          ...headers
+        },
+        body,
+        signal: controller.signal
+      });
+
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(`Vector DB request failed: ${response.status} ${response.statusText} ${text}`.trim());
+      }
+
+      if (response.status === 204) {
+        return null;
+      }
+
+      const contentType = response.headers.get('content-type');
+      if (contentType && contentType.includes('application/json')) {
+        return await response.json();
+      }
+
+      return await response.text();
+    } catch (error) {
+      if (error.name === 'AbortError') {
+        throw new Error('Vector DB request timed out');
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  async ensureCollection() {
+    try {
+      await this.fetchJson(`/collections/${this.collection}`);
+      this.ready = true;
+      return;
+    } catch (error) {
+      if (!/404/.test(error.message)) {
+        throw error;
+      }
+    }
+
+    const payload = {
+      vectors: {
+        size: this.dimensions,
+        distance: 'Cosine'
+      }
+    };
+
+    await this.fetchJson(`/collections/${this.collection}`, {
+      method: 'PUT',
+      body: JSON.stringify(payload)
+    });
+
+    this.ready = true;
+  }
+
+  async ensureReady() {
+    if (this.ready) return;
+    await this.ensureCollection();
+  }
+
+  async upsertDocuments(documents = []) {
+    if (!documents.length) {
+      return { upserted: 0 };
+    }
+
+    await this.ensureReady();
+
+    const points = documents.map(doc => {
+      const vector = Array.isArray(doc.vector) ? doc.vector : this.embedText(doc.text || '');
+      const payload = doc.metadata || {};
+      if (doc.id && !payload.id) {
+        payload.id = doc.id;
+      }
+      if (doc.name && !payload.name) {
+        payload.name = doc.name;
+      }
+      if (doc.description && !payload.description) {
+        payload.description = doc.description;
+      }
+      if (doc.categories && !payload.categories) {
+        payload.categories = doc.categories;
+      }
+
+      return {
+        id: doc.id || payload.id,
+        vector,
+        payload
+      };
+    });
+
+    await this.fetchJson(`/collections/${this.collection}/points?wait=true`, {
+      method: 'PUT',
+      body: JSON.stringify({ points })
+    });
+
+    return { upserted: points.length };
+  }
+
+  async deleteDocuments(ids = []) {
+    if (!ids.length) {
+      return { deleted: 0 };
+    }
+
+    await this.ensureReady();
+
+    await this.fetchJson(`/collections/${this.collection}/points/delete`, {
+      method: 'POST',
+      body: JSON.stringify({ points: ids })
+    });
+
+    return { deleted: ids.length };
+  }
+
+  async query({ query, topK = 10, filter = null, scoreThreshold = null } = {}) {
+    await this.ensureReady();
+
+    const vector = Array.isArray(query) ? query : this.embedText(query || '');
+
+    const payload = {
+      vector,
+      limit: topK,
+      with_payload: true,
+      with_vector: false
+    };
+
+    if (filter) {
+      payload.filter = filter;
+    }
+
+    if (typeof scoreThreshold === 'number') {
+      payload.score_threshold = scoreThreshold;
+    }
+
+    const response = await this.fetchJson(`/collections/${this.collection}/points/search`, {
+      method: 'POST',
+      body: JSON.stringify(payload)
+    });
+
+    const results = (response?.result || []).map(item => ({
+      id: item.payload?.id || item.id,
+      name: item.payload?.name || item.id,
+      description: item.payload?.description || '',
+      categories: item.payload?.categories || [],
+      score: item.score,
+      source: 'vector-db',
+      payload: item.payload
+    }));
+
+    return results;
+  }
+
+  async health() {
+    try {
+      await this.ensureCollection();
+      const stats = await this.fetchJson(`/collections/${this.collection}`);
+      return {
+        status: 'ready',
+        collection: this.collection,
+        vectors: stats?.result?.vectors_count ?? null
+      };
+    } catch (error) {
+      return {
+        status: 'error',
+        error: error.message
+      };
+    }
+  }
+
+  async bootstrapRegistry({ force = false } = {}) {
+    if (!this.registry) {
+      return { bootstrapped: 0 };
+    }
+
+    await this.ensureReady();
+
+    if (!force) {
+      try {
+        const info = await this.fetchJson(`/collections/${this.collection}`);
+        const vectors = info?.result?.vectors_count || 0;
+        if (vectors > 0) {
+          return { bootstrapped: 0, skipped: true, existing: vectors };
+        }
+      } catch (error) {
+        // Ignore and proceed
+      }
+    }
+
+    const docs = Object.entries(this.registry.getAll()).map(([id, info]) => ({
+      id: `mcp:${id}`,
+      name: info.name,
+      description: info.description,
+      categories: info.categories || [],
+      metadata: {
+        id,
+        name: info.name,
+        description: info.description,
+        categories: info.categories || [],
+        package: info.package,
+        command: info.command,
+        args: info.args
+      },
+      text: `${info.name}\n${info.description || ''}\n${(info.categories || []).join(' ')}`
+    }));
+
+    const result = await this.upsertDocuments(docs);
+    return { bootstrapped: result.upserted };
+  }
+}
+
+export default VectorRetriever;
+EOF
+rm wtf-mcp-manager/lib/router/vector-retriever.js
+cat <<'EOF' > wtf-mcp-manager/lib/router/vector-retriever.js
+#!/usr/bin/env node
+/**
+ * Vector retriever for the WTF MCP router.
+ * Provides utilities for embedding MCP metadata and
+ * storing/searching vectors inside a Qdrant-compatible database.
+ */
+
+import fetch from 'node-fetch';
+
+const DEFAULT_DIMENSIONS = 512;
+const DEFAULT_COLLECTION = 'wtf-mcp-router';
+
+export class VectorRetriever {
+  constructor(options = {}) {
+    this.vectorDbUrl = (options.vectorDbUrl || process.env.VECTOR_DB_URL || 'http://localhost:6333').replace(/\/$/, '');
+    this.collection = options.collection || process.env.VECTOR_DB_COLLECTION || DEFAULT_COLLECTION;
+    this.dimensions = options.dimensions || DEFAULT_DIMENSIONS;
+    this.timeoutMs = options.timeoutMs || 5000;
+    this.registry = options.registry;
+    this.ready = false;
+  }
+
+  /**
+   * Basic deterministic string hash. Adapted from Java's String.hashCode.
+   */
+  hashToken(token) {
+    let hash = 0;
+    for (let i = 0; i < token.length; i++) {
+      hash = ((hash << 5) - hash) + token.charCodeAt(i);
+      hash |= 0; // Convert to 32bit integer
+    }
+    return hash;
+  }
+
+  /**
+   * Convert text into a fixed-size vector using hashed bag-of-words.
+   */
+  embedText(text) {
+    const tokens = (text || '')
+      .toLowerCase()
+      .split(/[^a-z0-9]+/i)
+      .filter(Boolean);
+
+    if (tokens.length === 0) {
+      return new Array(this.dimensions).fill(0);
+    }
+
+    const vector = new Array(this.dimensions).fill(0);
+
+    tokens.forEach(token => {
+      const index = Math.abs(this.hashToken(token)) % this.dimensions;
+      vector[index] += 1;
+    });
+
+    // Normalize to unit length to make cosine similarity meaningful
+    const norm = Math.sqrt(vector.reduce((acc, value) => acc + (value * value), 0));
+    if (norm === 0) {
+      return vector;
+    }
+
+    return vector.map(value => value / norm);
+  }
+
+  async fetchJson(path, { method = 'GET', body, headers = {} } = {}) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const response = await fetch(`${this.vectorDbUrl}${path}`, {
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+          ...headers
+        },
+        body,
+        signal: controller.signal
+      });
+
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(`Vector DB request failed: ${response.status} ${response.statusText} ${text}`.trim());
+      }
+
+      if (response.status === 204) {
+        return null;
+      }
+
+      const contentType = response.headers.get('content-type');
+      if (contentType && contentType.includes('application/json')) {
+        return await response.json();
+      }
+
+      return await response.text();
+    } catch (error) {
+      if (error.name === 'AbortError') {
+        throw new Error('Vector DB request timed out');
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  async ensureCollection() {
+    try {
+      await this.fetchJson(`/collections/${this.collection}`);
+      this.ready = true;
+      return;
+    } catch (error) {
+      if (!/404/.test(error.message)) {
+        throw error;
+      }
+    }
+
+    const payload = {
+      vectors: {
+        size: this.dimensions,
+        distance: 'Cosine'
+      }
+    };
+
+    await this.fetchJson(`/collections/${this.collection}`, {
+      method: 'PUT',
+      body: JSON.stringify(payload)
+    });
+
+    this.ready = true;
+  }
+
+  async ensureReady() {
+    if (this.ready) return;
+    await this.ensureCollection();
+  }
+
+  async upsertDocuments(documents = []) {
+    if (!documents.length) {
+      return { upserted: 0 };
+    }
+
+    await this.ensureReady();
+
+    const points = documents.map(doc => {
+      const vector = Array.isArray(doc.vector) ? doc.vector : this.embedText(doc.text || '');
+      const payload = doc.metadata || {};
+      if (doc.id && !payload.id) {
+        payload.id = doc.id;
+      }
+      if (doc.name && !payload.name) {
+        payload.name = doc.name;
+      }
+      if (doc.description && !payload.description) {
+        payload.description = doc.description;
+      }
+      if (doc.categories && !payload.categories) {
+        payload.categories = doc.categories;
+      }
+
+      return {
+        id: doc.id || payload.id,
+        vector,
+        payload
+      };
+    });
+
+    await this.fetchJson(`/collections/${this.collection}/points?wait=true`, {
+      method: 'PUT',
+      body: JSON.stringify({ points })
+    });
+
+    return { upserted: points.length };
+  }
+
+  async deleteDocuments(ids = []) {
+    if (!ids.length) {
+      return { deleted: 0 };
+    }
+
+    await this.ensureReady();
+
+    await this.fetchJson(`/collections/${this.collection}/points/delete`, {
+      method: 'POST',
+      body: JSON.stringify({ points: ids })
+    });
+
+    return { deleted: ids.length };
+  }
+
+  async query({ query, topK = 10, filter = null, scoreThreshold = null } = {}) {
+    await this.ensureReady();
+
+    const vector = Array.isArray(query) ? query : this.embedText(query || '');
+
+    const payload = {
+      vector,
+      limit: topK,
+      with_payload: true,
+      with_vector: false
+    };
+
+    if (filter) {
+      payload.filter = filter;
+    }
+
+    if (typeof scoreThreshold === 'number') {
+      payload.score_threshold = scoreThreshold;
+    }
+
+    const response = await this.fetchJson(`/collections/${this.collection}/points/search`, {
+      method: 'POST',
+      body: JSON.stringify(payload)
+    });
+
+    const results = (response?.result || []).map(item => ({
+      id: item.payload?.id || item.id,
+      name: item.payload?.name || item.id,
+      description: item.payload?.description || '',
+      categories: item.payload?.categories || [],
+      score: item.score,
+      source: 'vector-db',
+      payload: item.payload
+    }));
+
+    return results;
+  }
+
+  async health() {
+    try {
+      await this.ensureCollection();
+      const stats = await this.fetchJson(`/collections/${this.collection}`);
+      return {
+        status: 'ready',
+        collection: this.collection,
+        vectors: stats?.result?.vectors_count ?? null
+      };
+    } catch (error) {
+      return {
+        status: 'error',
+        error: error.message
+      };
+    }
+  }
+
+  async bootstrapRegistry({ force = false } = {}) {
+    if (!this.registry) {
+      return { bootstrapped: 0 };
+    }
+
+    await this.ensureReady();
+
+    if (!force) {
+      try {
+        const info = await this.fetchJson(`/collections/${this.collection}`);
+        const vectors = info?.result?.vectors_count || 0;
+        if (vectors > 0) {
+          return { bootstrapped: 0, skipped: true, existing: vectors };
+        }
+      } catch (error) {
+        // Ignore and proceed
+      }
+    }
+
+    const docs = Object.entries(this.registry.getAll()).map(([id, info]) => ({
+      id: `mcp:${id}`,
+      name: info.name,
+      description: info.description,
+      categories: info.categories || [],
+      metadata: {
+        id,
+        name: info.name,
+        description: info.description,
+        categories: info.categories || [],
+        package: info.package,
+        command: info.command,
+        args: info.args
+      },
+      text: `${info.name}\n${info.description || ''}\n${(info.categories || []).join(' ')}`
+    }));
+
+    const result = await this.upsertDocuments(docs);
+    return { bootstrapped: result.upserted };
+  }
+}
+
+export default VectorRetriever;

--- a/lib/server/http.js
+++ b/lib/server/http.js
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+/**
+ * Minimal HTTP wrapper exposing the vector router endpoints.
+ */
+
+import http from 'http';
+import { URL } from 'url';
+import { MCPRegistry } from '../registry.js';
+import { VectorRetriever } from '../router/vector-retriever.js';
+
+const PORT = parseInt(process.env.ROUTER_PORT || process.env.PORT || '3333', 10);
+const HOST = process.env.ROUTER_HOST || '0.0.0.0';
+const API_KEY = process.env.ROUTER_API_KEY || null;
+const AUTO_BOOTSTRAP = process.env.VECTOR_BOOTSTRAP !== 'false';
+const FORCE_BOOTSTRAP = process.env.VECTOR_BOOTSTRAP_FORCE === 'true';
+
+const registry = new MCPRegistry();
+const retriever = new VectorRetriever({ registry });
+let ready = false;
+
+async function initializeRetriever() {
+  try {
+    await retriever.ensureCollection();
+    if (AUTO_BOOTSTRAP) {
+      const result = await retriever.bootstrapRegistry({ force: FORCE_BOOTSTRAP });
+      if (!result.skipped) {
+        console.log(`📦 Bootstrapped ${result.bootstrapped || 0} MCP vectors into ${retriever.collection}`);
+      }
+    }
+    ready = true;
+    console.log(`🚀 Router ready on ${HOST}:${PORT} (collection: ${retriever.collection})`);
+  } catch (error) {
+    console.error('Failed to initialize vector retriever:', error.message);
+    ready = false;
+  }
+}
+
+function sendJson(res, statusCode, payload) {
+  const body = JSON.stringify(payload);
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(body),
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type,x-api-key'
+  });
+  res.end(body);
+}
+
+async function parseBody(req) {
+  const chunks = [];
+  for await (const chunk of req) {
+    chunks.push(chunk);
+  }
+  if (!chunks.length) return {};
+
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString('utf8'));
+  } catch (error) {
+    throw new Error('Invalid JSON payload');
+  }
+}
+
+function authorize(req) {
+  if (!API_KEY) return true;
+  const key = req.headers['x-api-key'] || req.headers['X-Api-Key'];
+  return key === API_KEY;
+}
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204, {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type,x-api-key'
+    });
+    return res.end();
+  }
+
+  if (!authorize(req)) {
+    return sendJson(res, 401, { error: 'Unauthorized' });
+  }
+
+  if (url.pathname === '/health') {
+    const status = await retriever.health();
+    return sendJson(res, 200, { status: ready ? 'ready' : 'initializing', vectorDb: status });
+  }
+
+  if (!ready) {
+    return sendJson(res, 503, { error: 'Vector retriever not ready' });
+  }
+
+  try {
+    if (req.method === 'POST' && url.pathname === '/router/query') {
+      const body = await parseBody(req);
+      const results = await retriever.query({
+        query: body.query,
+        topK: body.topK,
+        filter: body.filter,
+        scoreThreshold: body.scoreThreshold
+      });
+      return sendJson(res, 200, { results });
+    }
+
+    if (req.method === 'POST' && url.pathname === '/router/upsert') {
+      const body = await parseBody(req);
+      const result = await retriever.upsertDocuments(body.documents || []);
+      return sendJson(res, 200, result);
+    }
+
+    if (req.method === 'POST' && url.pathname === '/router/delete') {
+      const body = await parseBody(req);
+      const result = await retriever.deleteDocuments(body.ids || []);
+      return sendJson(res, 200, result);
+    }
+
+    return sendJson(res, 404, { error: 'Not found' });
+  } catch (error) {
+    console.error('Router error:', error.message);
+    return sendJson(res, 500, { error: error.message });
+  }
+});
+
+server.listen(PORT, HOST, () => {
+  console.log(`🔌 Starting MCP router on http://${HOST}:${PORT}`);
+  initializeRetriever();
+});
+
+process.on('SIGINT', () => {
+  console.log('\n👋 Shutting down router');
+  server.close(() => process.exit(0));
+});
+
+process.on('SIGTERM', () => {
+  server.close(() => process.exit(0));
+});

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "lint": "eslint lib/",
     "prepare": "npm run build",
     "build": "echo 'Build complete'",
-    "postinstall": "node scripts/postinstall.js || true"
+    "postinstall": "node scripts/postinstall.js || true",
+    "router": "node lib/server/http.js",
+    "profile:router": "node --prof lib/server/http.js"
   },
   "keywords": [
     "claude",


### PR DESCRIPTION
## Summary
- add a vector-retrieval client/server layer so the MCP server and CLI prefer the HTTP router when available
- introduce a router search command, container image, and docker-compose stack that deploys the router alongside Qdrant
- document setup, environment variables, security guidance, and profiling workflows for the new service

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e17ce987288326898a981a37cf2fae