### PR TITLE
Add vector-based MCP retrieval and tests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,13 +2,17 @@
  * WTF-MCP-Manager Main Entry Point
  */
 
-export { MCPManager } from './manager.js';
-export { MCPRegistry } from './registry.js';
-export { AutoDetector } from './detector.js';
+import { MCPManager } from './manager.js';
+import { MCPRegistry } from './registry.js';
+import { AutoDetector } from './detector.js';
+import { VectorRouter } from './router/vector-router.js';
+
+export { MCPManager, MCPRegistry, AutoDetector, VectorRouter };
 
 // Re-export for convenience
 export default {
   MCPManager,
   MCPRegistry,
-  AutoDetector
+  AutoDetector,
+  VectorRouter
 };

--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -15,14 +15,16 @@ import { MCPRegistry } from './registry.js';
 import { AutoDetector } from './detector.js';
 import { DynamicMCPGenerator } from './dynamic/mcp-generator.js';
 import { APIDiscoveryService } from './discovery/api-discovery.js';
+import { VectorRouter } from './router/vector-router.js';
 
 class WTFMCPManagerServer {
-  constructor() {
+  constructor(options = {}) {
     this.manager = new MCPManager();
     this.registry = new MCPRegistry();
     this.detector = new AutoDetector();
     this.generator = new DynamicMCPGenerator();
     this.discovery = new APIDiscoveryService();
+    this.vectorRouter = options.vectorRouter || new VectorRouter(options.vectorRouterOptions || {});
     this.availableMCPs = null;
     this.lastFetchTime = null;
     this.FETCH_CACHE_TTL = 30 * 60 * 1000; // 30 minutes
@@ -33,6 +35,16 @@ class WTFMCPManagerServer {
   async initialize() {
     await this.generator.init();
     console.error('🚀 Dynamic MCP Generator initialized');
+
+    if (this.vectorRouter?.ensureReady) {
+      try {
+        await this.vectorRouter.ensureReady();
+        const label = this.vectorRouter.getSourceLabel ? this.vectorRouter.getSourceLabel() : 'memory';
+        console.error(`🧠 Vector router initialized (${label})`);
+      } catch (error) {
+        console.error('⚠️  Vector router failed to initialize:', error.message);
+      }
+    }
   }
 
   /**
@@ -125,12 +137,19 @@ class WTFMCPManagerServer {
     // Use cache if available and not expired
     if (!force && this.registryText && this.lastFetchTime &&
         (now - this.lastFetchTime) < this.FETCH_CACHE_TTL) {
+      if (!this.availableMCPs) {
+        const parsed = this.parseMCPRegistry(this.registryText);
+        this.availableMCPs = parsed;
+        await this.updateVectorIndexFromRegistry(parsed);
+      }
+
       return {
         success: true,
         cached: true,
         lastFetch: new Date(this.lastFetchTime).toISOString(),
         sourceSize: this.registryText.length,
         rawText: this.registryText,
+        vectorSource: this.vectorRouter?.getSourceLabel?.(),
         message: "Using cached MCP registry (use force: true to refresh)"
       };
     }
@@ -146,6 +165,10 @@ class WTFMCPManagerServer {
       const text = await response.text();
       console.log(`📦 Fetched ${text.length} characters from registry`);
 
+      const parsedRegistry = this.parseMCPRegistry(text);
+      this.availableMCPs = parsedRegistry;
+      await this.updateVectorIndexFromRegistry(parsedRegistry, { force: true });
+
       // Don't parse - just return the raw text for Claude to analyze
       this.lastFetchTime = now;
       this.registryText = text;
@@ -156,6 +179,7 @@ class WTFMCPManagerServer {
         lastFetch: new Date(this.lastFetchTime).toISOString(),
         sourceSize: text.length,
         rawText: text,
+        vectorSource: this.vectorRouter?.getSourceLabel?.(),
         message: "Here's the full MCP registry. You can search through it to find relevant MCPs for the user's needs."
       };
     } catch (error) {
@@ -164,13 +188,15 @@ class WTFMCPManagerServer {
       // Fallback to built-in registry
       this.availableMCPs = this.registry.getAll();
       this.lastFetchTime = now;
+      await this.updateVectorIndexFromRegistry(this.availableMCPs, { force: true });
 
       return {
         mcps: this.availableMCPs,
         cached: false,
         fallback: true,
         error: error.message,
-        count: Object.keys(this.availableMCPs).length
+        count: Object.keys(this.availableMCPs).length,
+        vectorSource: this.vectorRouter?.getSourceLabel?.()
       };
     }
   }
@@ -300,6 +326,55 @@ class WTFMCPManagerServer {
     return categories.length > 0 ? categories : ['general'];
   }
 
+  normalizeRegistryEntries(entries) {
+    if (!entries) {
+      return [];
+    }
+
+    if (Array.isArray(entries)) {
+      return entries.map(entry => ({
+        id: entry.id,
+        name: entry.name || this.formatMCPName(entry.id),
+        description: entry.description || '',
+        categories: entry.categories || [],
+        package: entry.package,
+        command: entry.command,
+        args: entry.args,
+        requiredEnv: entry.requiredEnv || [],
+        source: entry.source || 'registry'
+      })).filter(item => item.id);
+    }
+
+    return Object.entries(entries).map(([id, info]) => ({
+      id,
+      name: info.name || this.formatMCPName(id),
+      description: info.description || '',
+      categories: info.categories || [],
+      package: info.package,
+      command: info.command,
+      args: info.args,
+      requiredEnv: info.requiredEnv || [],
+      source: info.source || 'registry'
+    }));
+  }
+
+  async updateVectorIndexFromRegistry(entries, options = {}) {
+    if (!this.vectorRouter?.ingestTools) {
+      return;
+    }
+
+    const normalized = this.normalizeRegistryEntries(entries);
+    if (normalized.length === 0) {
+      return;
+    }
+
+    try {
+      await this.vectorRouter.ingestTools(normalized, options);
+    } catch (error) {
+      console.error('Failed to update vector index:', error.message);
+    }
+  }
+
   /**
    * Process MCP server requests
    */
@@ -358,6 +433,9 @@ class WTFMCPManagerServer {
           // Fallback to basic search
           const searchResults = await this.searchMCPs(params.query || '');
           return searchResults;
+
+        case 'retrieve_relevant_tools':
+          return await this.retrieveRelevantTools(params.query || '', params.limit);
 
         case 'diagnose':
           return await this.manager.diagnose();
@@ -447,11 +525,64 @@ class WTFMCPManagerServer {
       });
 
       if (score > 0) {
-        results.push({ ...mcp, score });
+        results.push({ id, ...mcp, score });
       }
     }
 
     return results.sort((a, b) => b.score - a.score).slice(0, 10);
+  }
+
+  async retrieveRelevantTools(query, limit = 5) {
+    const sanitizedQuery = (query || '').trim();
+    const maxResults = Math.max(1, Math.min(limit || 5, 50));
+    const availableMap = this.availableMCPs || this.registry.getAll();
+    const normalizedEntries = this.normalizeRegistryEntries(availableMap);
+
+    if (!sanitizedQuery) {
+      return {
+        query: sanitizedQuery,
+        limit: maxResults,
+        source: 'fallback',
+        vectorStoreAvailable: this.vectorRouter?.isAvailable?.() ?? false,
+        tools: normalizedEntries.slice(0, maxResults)
+      };
+    }
+
+    let results = [];
+    let source = 'fallback';
+
+    if (this.vectorRouter?.query) {
+      try {
+        results = await this.vectorRouter.query(sanitizedQuery, maxResults);
+        if (results.length > 0) {
+          source = this.vectorRouter.getSourceLabel ? this.vectorRouter.getSourceLabel() : 'vector';
+        }
+      } catch (error) {
+        console.error('Vector retrieval failed:', error.message);
+      }
+    }
+
+    if (!results || results.length === 0) {
+      const fallbackResults = await this.searchMCPs(sanitizedQuery);
+      results = fallbackResults.slice(0, maxResults).map(result => ({
+        id: result.id,
+        name: result.name || this.formatMCPName(result.id),
+        description: result.description || '',
+        categories: result.categories || [],
+        package: result.package,
+        score: result.score || 0,
+        source: 'fallback'
+      }));
+      source = 'fallback';
+    }
+
+    return {
+      query: sanitizedQuery,
+      limit: maxResults,
+      source,
+      vectorStoreAvailable: this.vectorRouter?.isAvailable?.() ?? false,
+      tools: results
+    };
   }
 
   async suggestMCPs(requirements) {

--- a/lib/router/vector-router.js
+++ b/lib/router/vector-router.js
@@ -1,0 +1,448 @@
+import { createHash } from 'crypto';
+
+/**
+ * VectorRouter
+ * Embeds MCP metadata into a vector store (Qdrant/Chroma) with a memory fallback
+ */
+export class VectorRouter {
+  constructor(options = {}) {
+    this.collectionName = options.collectionName || 'wtf-mcp-tools';
+    this.dimensions = options.dimensions || 128;
+    this.clientFactory = options.clientFactory;
+    this.options = options;
+
+    this.vectorClient = null;
+    this.mode = 'uninitialized';
+    this.memoryStore = new Map();
+    this.lastSignature = null;
+    this.lastError = null;
+
+    this.initialized = false;
+    this.initializing = null;
+  }
+
+  /**
+   * Initialize the router (attempt remote connection, otherwise fallback to memory)
+   */
+  async ensureReady() {
+    if (this.initialized) {
+      return;
+    }
+
+    if (!this.initializing) {
+      this.initializing = this.initialize();
+    }
+
+    await this.initializing;
+  }
+
+  async initialize() {
+    try {
+      if (this.clientFactory) {
+        const candidate = await this.clientFactory();
+        if (candidate && candidate.client) {
+          this.vectorClient = candidate.client;
+          this.mode = candidate.type || 'vector';
+
+          try {
+            await this.ensureRemoteCollection();
+            this.initialized = true;
+            return;
+          } catch (error) {
+            this.lastError = error;
+            this.vectorClient = null;
+            this.mode = 'unavailable';
+          }
+        }
+      }
+
+      if (await this.tryConnectQdrant()) {
+        this.initialized = true;
+        return;
+      }
+
+      if (await this.tryConnectChroma()) {
+        this.initialized = true;
+        return;
+      }
+    } catch (error) {
+      this.lastError = error;
+    }
+
+    // Default to in-memory store
+    this.vectorClient = null;
+    this.mode = 'memory';
+    this.initialized = true;
+  }
+
+  async tryConnectQdrant() {
+    const url = this.options.qdrantUrl || process.env.QDRANT_URL || process.env.QDRANT_HOST;
+    if (!url) {
+      return false;
+    }
+
+    try {
+      const module = await import('@qdrant/js-client-rest');
+      const QdrantClient = module.QdrantClient || module.default;
+      if (!QdrantClient) {
+        return false;
+      }
+
+      const apiKey = this.options.qdrantApiKey || process.env.QDRANT_API_KEY;
+      this.vectorClient = new QdrantClient({ url, apiKey });
+      this.mode = 'qdrant';
+
+      await this.ensureRemoteCollection();
+      return true;
+    } catch (error) {
+      this.lastError = error;
+      this.vectorClient = null;
+      this.mode = 'memory';
+      return false;
+    }
+  }
+
+  async tryConnectChroma() {
+    const url = this.options.chromaUrl || process.env.CHROMA_URL || process.env.CHROMA_HOST;
+    if (!url) {
+      return false;
+    }
+
+    try {
+      const module = await import('chromadb');
+      const ChromaClient = module.ChromaClient || module.default;
+      if (!ChromaClient) {
+        return false;
+      }
+
+      const client = new ChromaClient({ path: url });
+      this.vectorClient = await client.getOrCreateCollection({
+        name: this.collectionName,
+        metadata: { source: 'wtf-mcp-manager' },
+        embeddingFunction: {
+          embedDocuments: docs => docs.map(doc => this.computeEmbedding(doc)),
+          embedQuery: doc => this.computeEmbedding(doc)
+        }
+      });
+      this.mode = 'chroma';
+      return true;
+    } catch (error) {
+      this.lastError = error;
+      this.vectorClient = null;
+      this.mode = 'memory';
+      return false;
+    }
+  }
+
+  async ensureRemoteCollection() {
+    if (this.mode === 'qdrant' && this.vectorClient) {
+      try {
+        await this.vectorClient.getCollection(this.collectionName);
+      } catch (error) {
+        if (error?.status === 404 || error?.response?.status === 404) {
+          await this.vectorClient.createCollection(this.collectionName, {
+            vectors: {
+              size: this.dimensions,
+              distance: 'Cosine'
+            }
+          });
+        } else {
+          throw error;
+        }
+      }
+    }
+  }
+
+  getSourceLabel() {
+    return this.mode;
+  }
+
+  isAvailable() {
+    return this.mode !== 'unavailable';
+  }
+
+  async ingestTools(tools = [], options = {}) {
+    await this.ensureReady();
+
+    if (!Array.isArray(tools) || tools.length === 0) {
+      return { ingested: 0, mode: this.mode, skipped: true };
+    }
+
+    const normalizedTools = tools
+      .map(tool => this.normalizeTool(tool))
+      .filter(Boolean);
+
+    if (normalizedTools.length === 0) {
+      return { ingested: 0, mode: this.mode, skipped: true };
+    }
+
+    const signature = this.createSignature(normalizedTools);
+    if (!options.force && signature === this.lastSignature) {
+      return { ingested: 0, mode: this.mode, skipped: true };
+    }
+
+    if (this.mode === 'qdrant' && this.vectorClient) {
+      try {
+        const points = normalizedTools.map(tool => ({
+          id: tool.id,
+          vector: this.computeEmbedding(this.serializeTool(tool)),
+          payload: tool
+        }));
+        await this.vectorClient.upsert(this.collectionName, { points });
+        this.lastSignature = signature;
+        return { ingested: normalizedTools.length, mode: this.mode };
+      } catch (error) {
+        this.lastError = error;
+        this.vectorClient = null;
+        this.mode = 'memory';
+      }
+    }
+
+    if (this.mode === 'chroma' && this.vectorClient) {
+      try {
+        const ids = normalizedTools.map(tool => tool.id);
+        const documents = normalizedTools.map(tool => this.serializeTool(tool));
+        const metadatas = normalizedTools.map(tool => tool);
+
+        if (typeof this.vectorClient.upsert === 'function') {
+          await this.vectorClient.upsert({ ids, documents, metadatas });
+        } else if (typeof this.vectorClient.add === 'function') {
+          await this.vectorClient.add({ ids, documents, metadatas });
+        }
+
+        this.lastSignature = signature;
+        return { ingested: normalizedTools.length, mode: this.mode };
+      } catch (error) {
+        this.lastError = error;
+        this.vectorClient = null;
+        this.mode = 'memory';
+      }
+    }
+
+    // Memory fallback ingestion
+    this.memoryStore.clear();
+    normalizedTools.forEach(tool => {
+      const vector = this.computeEmbedding(this.serializeTool(tool));
+      this.memoryStore.set(tool.id, { vector, metadata: tool });
+    });
+
+    this.lastSignature = signature;
+    if (this.mode === 'uninitialized') {
+      this.mode = 'memory';
+    }
+
+    return { ingested: normalizedTools.length, mode: this.mode };
+  }
+
+  async query(query, limit = 5) {
+    await this.ensureReady();
+
+    const sanitizedQuery = (query || '').trim();
+    if (!sanitizedQuery) {
+      return [];
+    }
+
+    const maxResults = Math.max(1, Math.min(limit || 5, 50));
+
+    if (this.mode === 'qdrant' && this.vectorClient) {
+      try {
+        const vector = this.computeEmbedding(sanitizedQuery);
+        const response = await this.vectorClient.search(this.collectionName, {
+          vector,
+          limit: maxResults
+        });
+
+        if (Array.isArray(response)) {
+          return response.map(point => {
+            const payload = this.normalizeTool(point.payload || {});
+            return {
+              ...payload,
+              score: typeof point.score === 'number' ? point.score : 0,
+              source: this.mode
+            };
+          });
+        }
+      } catch (error) {
+        this.lastError = error;
+        this.vectorClient = null;
+        this.mode = 'memory';
+      }
+    }
+
+    if (this.mode === 'chroma' && this.vectorClient) {
+      try {
+        const response = await this.vectorClient.query({
+          queryTexts: [sanitizedQuery],
+          nResults: maxResults
+        });
+
+        const ids = response.ids?.[0] || [];
+        const metadatas = response.metadatas?.[0] || [];
+        const distances = response.distances?.[0] || [];
+        const results = [];
+
+        for (let index = 0; index < ids.length; index++) {
+          const metadata = this.normalizeTool({ id: ids[index], ...(metadatas[index] || {}) });
+          results.push({
+            ...metadata,
+            score: typeof distances[index] === 'number' ? distances[index] : 0,
+            source: this.mode
+          });
+        }
+
+        if (results.length > 0) {
+          return results;
+        }
+      } catch (error) {
+        this.lastError = error;
+        this.vectorClient = null;
+        this.mode = 'memory';
+      }
+    }
+
+    // Memory search fallback
+    const queryVector = this.computeEmbedding(sanitizedQuery);
+    const scored = [];
+
+    for (const { vector, metadata } of this.memoryStore.values()) {
+      const score = this.cosineSimilarity(queryVector, vector);
+      scored.push({ metadata, score });
+    }
+
+    return scored
+      .sort((a, b) => b.score - a.score)
+      .slice(0, maxResults)
+      .map(({ metadata, score }) => ({
+        ...metadata,
+        score,
+        source: this.mode === 'unavailable' ? 'fallback' : this.mode
+      }));
+  }
+
+  normalizeTool(tool) {
+    if (!tool) {
+      return null;
+    }
+
+    const inferredId = tool.id || this.slugify(tool.name || tool.package || tool.command || `tool-${Math.random()}`);
+    const categories = Array.isArray(tool.categories)
+      ? tool.categories
+      : tool.categories
+        ? [tool.categories]
+        : [];
+
+    const requiredEnv = Array.isArray(tool.requiredEnv)
+      ? tool.requiredEnv
+      : tool.requiredEnv
+        ? [tool.requiredEnv]
+        : [];
+
+    return {
+      id: inferredId,
+      name: tool.name || this.formatNameFromId(inferredId),
+      description: tool.description || '',
+      package: tool.package || '',
+      categories,
+      command: tool.command,
+      args: tool.args,
+      requiredEnv,
+      source: tool.source || tool.origin || 'registry'
+    };
+  }
+
+  formatNameFromId(id) {
+    return (id || '')
+      .split(/[-_]/)
+      .filter(Boolean)
+      .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(' ');
+  }
+
+  slugify(value) {
+    return (value || '')
+      .toString()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/(^-|-$)/g, '')
+      || 'tool';
+  }
+
+  serializeTool(tool) {
+    const sections = [
+      tool.id,
+      tool.name,
+      tool.description,
+      Array.isArray(tool.categories) ? tool.categories.join(' ') : '',
+      Array.isArray(tool.requiredEnv) ? tool.requiredEnv.join(' ') : '',
+      Array.isArray(tool.args) ? tool.args.join(' ') : ''
+    ];
+
+    if (tool.package) {
+      sections.push(tool.package);
+    }
+
+    if (tool.command) {
+      sections.push(tool.command);
+    }
+
+    return sections.filter(Boolean).join(' ');
+  }
+
+  createSignature(tools) {
+    const hash = createHash('sha256');
+    const sorted = [...tools].sort((a, b) => a.id.localeCompare(b.id));
+
+    for (const tool of sorted) {
+      hash.update(tool.id);
+      hash.update('|');
+      hash.update(tool.name || '');
+      hash.update('|');
+      hash.update(tool.description || '');
+    }
+
+    return hash.digest('hex');
+  }
+
+  computeEmbedding(text) {
+    const tokens = (text || '')
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter(Boolean);
+
+    const vector = new Array(this.dimensions).fill(0);
+
+    tokens.forEach(token => {
+      const hash = this.simpleHash(token);
+      const index = hash % this.dimensions;
+      vector[index] += 1;
+    });
+
+    const norm = Math.sqrt(vector.reduce((sum, value) => sum + value * value, 0)) || 1;
+    return vector.map(value => value / norm);
+  }
+
+  simpleHash(token) {
+    let hash = 0;
+    for (let i = 0; i < token.length; i++) {
+      hash = (hash * 31 + token.charCodeAt(i)) >>> 0;
+    }
+    return hash;
+  }
+
+  cosineSimilarity(a, b) {
+    let dot = 0;
+    let normA = 0;
+    let normB = 0;
+
+    for (let i = 0; i < Math.min(a.length, b.length); i++) {
+      dot += a[i] * b[i];
+      normA += a[i] * a[i];
+      normB += b[i] * b[i];
+    }
+
+    const denominator = Math.sqrt(normA) * Math.sqrt(normB) || 1;
+    return dot / denominator;
+  }
+}
+
+export default VectorRouter;

--- a/test/vector-router.test.js
+++ b/test/vector-router.test.js
@@ -1,0 +1,92 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { VectorRouter } from '../lib/router/vector-router.js';
+import { WTFMCPManagerServer } from '../lib/mcp-server.js';
+
+const SAMPLE_TOOLS = [
+  {
+    id: 'github',
+    name: 'GitHub',
+    description: 'Repository hosting and version control for code projects',
+    categories: ['development', 'vcs'],
+    package: '@modelcontextprotocol/server-github'
+  },
+  {
+    id: 'supabase',
+    name: 'Supabase',
+    description: 'Database, authentication, and storage platform',
+    categories: ['database', 'storage'],
+    package: '@supabase/mcp-server-supabase'
+  },
+  {
+    id: 'vercel',
+    name: 'Vercel',
+    description: 'Cloud hosting platform focused on front-end deployments',
+    categories: ['deployment', 'cloud'],
+    package: '@modelcontextprotocol/server-vercel'
+  },
+  {
+    id: 'docker',
+    name: 'Docker',
+    description: 'Container orchestration and image management',
+    categories: ['containers', 'devops'],
+    package: '@modelcontextprotocol/server-docker'
+  }
+];
+
+const SAMPLE_MAP = Object.fromEntries(SAMPLE_TOOLS.map(tool => [tool.id, tool]));
+
+test('VectorRouter ingests metadata and retrieves similar tools', async () => {
+  const router = new VectorRouter({ dimensions: 64 });
+  const ingestResult = await router.ingestTools(SAMPLE_TOOLS, { force: true });
+
+  assert.equal(ingestResult.ingested, SAMPLE_TOOLS.length, 'all tools should be indexed');
+
+  const matches = await router.query('version control and repositories', 2);
+  assert.ok(Array.isArray(matches) && matches.length > 0, 'should return at least one match');
+  assert.equal(matches[0].id, 'github', 'GitHub should be the top match for repository queries');
+});
+
+test('retrieve_relevant_tools uses vector matches when available', async () => {
+  const router = new VectorRouter({ dimensions: 64 });
+  const server = new WTFMCPManagerServer({ vectorRouter: router });
+  server.availableMCPs = SAMPLE_MAP;
+
+  await router.ingestTools(SAMPLE_TOOLS, { force: true });
+
+  const response = await server.retrieveRelevantTools('cloud deployment hosting', 2);
+  assert.ok(response.tools.length > 0, 'should return relevant tools');
+  assert.ok(response.tools.some(tool => tool.id === 'vercel'), 'Vercel should be suggested for deployment queries');
+  assert.notEqual(response.source, 'fallback', 'should not rely on fallback when vector router is available');
+});
+
+test('retrieve_relevant_tools gracefully falls back when vector store is unavailable', async () => {
+  class FailingRouter {
+    getSourceLabel() {
+      return 'unavailable';
+    }
+
+    isAvailable() {
+      return false;
+    }
+
+    async ensureReady() {}
+
+    async ingestTools() {
+      throw new Error('vector store offline');
+    }
+
+    async query() {
+      throw new Error('vector store offline');
+    }
+  }
+
+  const router = new FailingRouter();
+  const server = new WTFMCPManagerServer({ vectorRouter: router });
+  server.availableMCPs = SAMPLE_MAP;
+
+  const response = await server.retrieveRelevantTools('version control and repositories', 3);
+  assert.equal(response.source, 'fallback', 'should report fallback source');
+  assert.ok(response.tools.some(tool => tool.id === 'github'), 'fallback search should still surface relevant tools');
+});


### PR DESCRIPTION
## Summary
- add a VectorRouter module that handles embedding MCP metadata and querying vector stores with an in-memory fallback
- integrate the MCP server with the router to refresh the index on registry updates and expose a new retrieve_relevant_tools handler
- add unit tests that cover ingestion, retrieval, and graceful fallback when the vector store is unavailable

## Testing
- node --test test/vector-router.test.js
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e17cee3fe8832690124d02c130139e