### PR TITLE
fix: remove duplicate imports in entry point

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,10 +4,6 @@
 import { MCPManager } from './manager.js';
 import { MCPRegistry } from './registry.js';
 import { AutoDetector } from './detector.js';
-
-import { MCPManager } from './manager.js';
-import { MCPRegistry } from './registry.js';
-import { AutoDetector } from './detector.js';
 import { VectorRouter } from './router/vector-router.js';
 
 export { MCPManager, MCPRegistry, AutoDetector, VectorRouter };


### PR DESCRIPTION
## Summary
- remove duplicate import declarations from the primary library entrypoint
- ensure each module is imported exactly once, including the vector router

## Testing
- npm test *(fails: existing SyntaxError in lib/mcp-server.js and missing MCPVectorRetriever export)*

------
https://chatgpt.com/codex/tasks/task_e_68e1e58812288326b2907d6e734743e7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Refactor
  * Removed redundant internal imports to streamline module initialization and reduce duplication. No changes to functionality, behavior, or outputs. May slightly improve build clarity and maintainability.

* Chores
  * Preserved existing exports to ensure full backward compatibility. No configuration or migration required for users. Potential minor improvements to build consistency without affecting runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->