### PR TITLE
Fix registry normalization helper usage in MCP server

### DIFF
--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -177,7 +177,7 @@ class WTFMCPManagerServer {
 
       const parsedRegistry = this.parseMCPRegistry(text);
       this.availableMCPs = parsedRegistry;
-      const normalizedRecords = this.normalizeRegistryRecords(Object.values(parsedRegistry));
+      const normalizedRecords = this.normalizeRegistryEntries(Object.values(parsedRegistry));
       this.registryToolRecords = normalizedRecords;
 
       const dataHash = createHash('sha256').update(text).digest('hex');


### PR DESCRIPTION
## Summary
- update the MCP server registry ingestion flow to call the existing normalizeRegistryEntries helper

## Testing
- `npm test` *(fails: existing SyntaxError imports in lib/index.js and other modules)*

------
https://chatgpt.com/codex/tasks/task_e_68e1e57ed52c8326865d5d4b803253c2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the internal registry parsing to use a newer normalization approach for registry entries. This aligns processing across components and is not expected to change user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->