### PR TITLE
Parse Node.js version numerically for diagnostics

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -8,6 +8,19 @@ import path from 'path';
 import { execSync } from 'child_process';
 import { MCPRegistry } from './registry.js';
 
+export function parseNodeVersion(versionString) {
+  if (typeof versionString !== 'string') return null;
+
+  const match = versionString.trim().match(/^v?(\d+)(?:\.(\d+))?/);
+  if (!match) return null;
+
+  const [, major, minor] = match;
+  return {
+    major: Number.parseInt(major, 10),
+    minor: minor !== undefined ? Number.parseInt(minor, 10) : null
+  };
+}
+
 export class MCPManager {
   constructor(projectRoot = process.cwd()) {
     this.projectRoot = projectRoot;
@@ -235,8 +248,9 @@ node_modules/
     }
     
     // Check Node.js version
-    const nodeVersion = process.version;
-    if (nodeVersion < 'v18.0.0') {
+    const nodeVersion = process.versions?.node || process.version;
+    const parsedNodeVersion = parseNodeVersion(nodeVersion);
+    if (parsedNodeVersion && parsedNodeVersion.major < 18) {
       issues.push({
         type: 'warning',
         message: `Node.js ${nodeVersion} is outdated`,

--- a/test/manager-version.test.js
+++ b/test/manager-version.test.js
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseNodeVersion } from '../lib/manager.js';
+
+test('parseNodeVersion extracts major and minor from prefixed versions', () => {
+  assert.deepEqual(parseNodeVersion('v8.0.0'), { major: 8, minor: 0 });
+  assert.deepEqual(parseNodeVersion('v20.10.0'), { major: 20, minor: 10 });
+});
+
+test('parseNodeVersion extracts versions without leading v', () => {
+  assert.deepEqual(parseNodeVersion('18.17.1'), { major: 18, minor: 17 });
+});
+
+test('parseNodeVersion handles missing minor segment', () => {
+  assert.deepEqual(parseNodeVersion('v16'), { major: 16, minor: null });
+});
+
+test('parseNodeVersion returns null for invalid input', () => {
+  assert.equal(parseNodeVersion('invalid'), null);
+  assert.equal(parseNodeVersion(undefined), null);
+});


### PR DESCRIPTION
## Summary
- add a helper that parses Node.js version strings into numeric parts
- base the diagnostic warning on the parsed major version instead of a string comparison
- add unit tests that exercise the version parsing helper with representative Node.js versions

## Testing
- npm test *(fails: existing suites import.test.js, retriever.test.js, vector-router.test.js due to duplicate exports prior to changes)*

------
https://chatgpt.com/codex/tasks/task_e_68e1e5757fa08326862b3a8760e33a72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved detection of outdated Node.js environments by using numeric version parsing.
  - Prefer a more reliable source for the Node.js version when available.
  - Avoids false warnings by skipping checks when the version cannot be parsed.

- Tests
  - Added comprehensive tests covering various Node.js version formats (with/without leading “v”, missing segments) and invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->