### PR TITLE
Ensure custom profiles exist before enabling MCPs

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -32,6 +32,8 @@ export class MCPManager {
       }
     }
     
+    const activeProfile = options.profile || 'default';
+
     // Create initial configuration
     this.config = {
       version: '1.0.0',
@@ -44,13 +46,17 @@ export class MCPManager {
         prod: [],
         test: []
       },
-      activeProfile: options.profile || 'default',
+      activeProfile,
       settings: {
         autoDetect: true,
         autoUpdate: false,
         lazy: true
       }
     };
+
+    if (!this.config.profiles[activeProfile]) {
+      this.config.profiles[activeProfile] = [];
+    }
     
     await this.save();
     
@@ -151,6 +157,9 @@ node_modules/
     
     // Add to current profile
     const profile = this.config.activeProfile;
+    if (!this.config.profiles[profile]) {
+      this.config.profiles[profile] = [];
+    }
     if (!this.config.profiles[profile].includes(mcpId)) {
       this.config.profiles[profile].push(mcpId);
     }

--- a/test/manager.test.js
+++ b/test/manager.test.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { MCPManager } from '../lib/manager.js';
+
+test('init and enable handle custom backend profile', async t => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcp-manager-'));
+
+  t.after(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const manager = new MCPManager(tempDir);
+
+  // Stub registry lookups so enable works without hitting the real registry
+  manager.registry.get = () => ({
+    command: 'node',
+    args: ['server.js'],
+    requiredEnv: []
+  });
+
+  const config = await manager.init({ profile: 'backend' });
+
+  assert.deepStrictEqual(
+    config.profiles.backend,
+    [],
+    'init should create an empty backend profile'
+  );
+  assert.strictEqual(config.activeProfile, 'backend');
+
+  // Simulate a missing backend profile entry to ensure enable lazily recreates it
+  delete manager.config.profiles.backend;
+
+  await manager.enable('sample-mcp');
+
+  assert.ok(
+    Array.isArray(manager.config.profiles.backend),
+    'backend profile should be recreated as an array'
+  );
+  assert.deepStrictEqual(manager.config.profiles.backend, ['sample-mcp']);
+  assert.ok(
+    manager.config.mcpServers['sample-mcp'],
+    'enabled MCP should be recorded in the configuration'
+  );
+});


### PR DESCRIPTION
## Summary
- ensure `init` seeds an entry for the active profile, including custom names like `backend`
- lazily create profile arrays during `enable` before checking membership or pushing MCP IDs
- add a regression test covering initialization and enabling with a custom profile

## Testing
- npm test *(fails: existing suites import.test.js, retriever.test.js, and vector-router.test.js currently error under `node --test`)*

------
https://chatgpt.com/codex/tasks/task_e_68e1e54512a4832687406276f1e8de7f