### PR TITLE
Ensure VectorStoreIngestor awaits embedding provider initialization

### DIFF
--- a/lib/router/vector-store.js
+++ b/lib/router/vector-store.js
@@ -133,7 +133,7 @@ export class MockEmbeddingClient extends EmbeddingClient {
 }
 
 class EmbeddingProviderFactory {
-  static create(options = {}) {
+  static async create(options = {}) {
     if (options.embeddingClient) {
       return options.embeddingClient;
     }
@@ -350,7 +350,16 @@ export class VectorStoreIngestor {
     };
 
     this.vectorDb = options.vectorDb || VectorDatabaseFactory.create(vectorOptions);
-    this.embeddingClient = options.embeddingClient || EmbeddingProviderFactory.create(embeddingOptions);
+    this.embeddingClient = options.embeddingClient || null;
+    this.embeddingClientPromise = (async () => {
+      if (this.embeddingClient) {
+        return this.embeddingClient;
+      }
+
+      const client = await EmbeddingProviderFactory.create(embeddingOptions);
+      this.embeddingClient = client;
+      return client;
+    })();
   }
 
   async collectRegistryDocuments() {
@@ -487,7 +496,8 @@ export class VectorStoreIngestor {
   }
 
   async embedDocuments(documents) {
-    const embeddings = await this.embeddingClient.embed(documents.map(doc => doc.text));
+    const embeddingClient = await this.embeddingClientPromise;
+    const embeddings = await embeddingClient.embed(documents.map(doc => doc.text));
     return documents.map((doc, index) => ({
       ...doc,
       embedding: embeddings[index]

--- a/test/vector-store.test.js
+++ b/test/vector-store.test.js
@@ -17,6 +17,33 @@ async function runVectorStoreTests() {
     embeddingProvider: 'mock'
   });
 
+  const sampleDocs = [
+    {
+      id: 'test:doc',
+      source: 'test',
+      name: 'Test Document',
+      description: 'Ensures async embedding initialization resolves correctly',
+      schema: null,
+      example: '',
+      text: 'Sample text for embedding',
+      metadata: {}
+    }
+  ];
+
+  const embeddedDocs = await ingestor.embedDocuments(sampleDocs);
+  assert.equal(embeddedDocs.length, sampleDocs.length, 'embedDocuments should return embeddings for all docs');
+  assert.ok(Array.isArray(embeddedDocs[0].embedding), 'embedded document should include an embedding array');
+  assert.ok(ingestor.embeddingClient, 'embedding client should be resolved after embedding');
+
+  const asyncIngestor = new VectorStoreIngestor({
+    vectorDb: new MemoryVectorDatabase(),
+    provider: 'memory',
+    embeddingProvider: 'mock'
+  });
+  const asyncEmbeddedDocs = await asyncIngestor.embedDocuments(sampleDocs);
+  assert.ok(Array.isArray(asyncEmbeddedDocs[0].embedding), 'async-created embedding client should embed documents');
+  assert.ok(asyncIngestor.embeddingClient, 'async-created embedding client should resolve during embedding');
+
   const result = await ingestor.ingestAll();
 
   assert.ok(result.count > 0, 'ingestion should create at least one document');


### PR DESCRIPTION
## Summary
- ensure the vector store ingestor resolves the embedding provider asynchronously before embedding documents
- extend the vector store test harness to verify embedDocuments works with both injected and factory-provided clients

## Testing
- npm test *(fails: existing module export issues in unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_68e1e53847808326a91748aac0c5350e