### PR TITLE
Fix RouterClient import in MCP server

### DIFF
--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -17,6 +17,7 @@ import { AutoDetector } from './detector.js';
 import { DynamicMCPGenerator } from './dynamic/mcp-generator.js';
 import { APIDiscoveryService } from './discovery/api-discovery.js';
 import { VectorRouter } from './router/vector-router.js';
+import { RouterClient } from './router/client.js';
 
 class WTFMCPManagerServer {
   constructor(options = {}) {


### PR DESCRIPTION
## Summary
- add the missing RouterClient import to the MCP server module so the router client is defined at runtime

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1e54e877c832682e6eb1bfc99e55a