### PR TITLE
Fix MCP search routing

### DIFF
--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -17,6 +17,7 @@ import { AutoDetector } from './detector.js';
 import { DynamicMCPGenerator } from './dynamic/mcp-generator.js';
 import { APIDiscoveryService } from './discovery/api-discovery.js';
 import { VectorRouter } from './router/vector-router.js';
+import { RouterClient } from './router/client.js';
 
 class WTFMCPManagerServer {
   constructor(options = {}) {
@@ -503,83 +504,47 @@ class WTFMCPManagerServer {
     }
   }
 
-  async searchMCPs(query) {
+  async searchMCPs(query, { limit = 10 } = {}) {
+    const sanitizedQuery = (query || '').trim();
+    if (!sanitizedQuery) {
+      return [];
+    }
+
     if (this.routerClient?.isConfigured) {
-      const remoteResults = await this.routerClient.query({ query, topK: 10 });
-      if (Array.isArray(remoteResults) && remoteResults.length > 0) {
-        return remoteResults;
-      }
-    }
-
-    // If we have registry text, search within it
-    if (this.registryText) {
-      const queryLower = query.toLowerCase();
-      const lines = this.registryText.split('\n');
-      const results = [];
-
-      lines.forEach(line => {
-        if (line.toLowerCase().includes(queryLower)) {
-          // Extract package name from the line
-          const match = line.match(/@[\w-]+\/[\w-]+|[\w-]+-mcp|mcp-[\w-]+/);
-          if (match) {
-            results.push({
-              name: match[0],
-              description: line,
-              relevance: 'high',
-              source: 'registry'
-            });
-          }
-        }
-      });
-
-      if (!response.ok) {
-        console.warn(`Router HTTP query failed with status ${response.status}`);
-        return null;
-      }
-
-      const data = await response.json();
-      if (Array.isArray(data.results)) {
-        return data.results.slice(0, limit);
-      }
-    } catch (error) {
-      console.warn('Router HTTP query error:', error.message || error);
-    }
-
-    return null;
-  }
-
-  async searchMCPs(query) {
-    const limit = 10;
-    const httpResults = await this.queryRouterHTTP(query, limit);
-    if (httpResults && httpResults.length > 0) {
-      return httpResults;
-    }
-
-    if (!this.availableMCPs) {
-      this.availableMCPs = this.registry.getAll();
-    }
-
-    return await this.routerRetriever.query(query, {
-      limit,
-      registryText: this.registryText,
-      availableMCPs: this.availableMCPs
-    });
-  }
-
-  searchMCPsLocal(query, limit = 10) {
-    if (!this.availableMCPs) {
-      this.availableMCPs = this.registry.getAll();
-      this.toolRetriever.setDocuments(this.availableMCPs);
-    }
-
-    if (this.retriever?.isEnabled()) {
       try {
-        const vectorResults = await this.retriever.retrieve(query, { topK: 10 });
-        if (vectorResults.length > 0) {
+        const remoteResults = await this.routerClient.query({ query: sanitizedQuery, topK: limit });
+        if (Array.isArray(remoteResults) && remoteResults.length > 0) {
+          return remoteResults;
+        }
+      } catch (error) {
+        console.warn('Remote router query failed, falling back to local search:', error.message || error);
+      }
+    }
+
+    return await this.searchMCPsLocal(sanitizedQuery, limit);
+  }
+
+  async searchMCPsLocal(query, limit = 10) {
+    if (!query || !query.trim()) {
+      return [];
+    }
+
+    if (!this.availableMCPs) {
+      this.availableMCPs = this.registry.getAll();
+      this.toolRetriever?.setDocuments?.(this.availableMCPs);
+    }
+
+    if (this.retriever?.isEnabled?.()) {
+      try {
+        const vectorResults = await this.retriever.retrieve(query, { topK: limit });
+        if (Array.isArray(vectorResults) && vectorResults.length > 0) {
           return vectorResults;
         }
       } catch (error) {
-        if (error instanceof VectorStoreUnavailableError) {
+        const vectorUnavailable = (typeof VectorStoreUnavailableError !== 'undefined') &&
+          (error instanceof VectorStoreUnavailableError);
+
+        if (vectorUnavailable) {
           console.warn('⚠️  Vector store unavailable, falling back to keyword search:', error.message);
         } else {
           console.error('Vector store retrieval failed, falling back to keyword search:', error);
@@ -587,7 +552,7 @@ class WTFMCPManagerServer {
       }
     }
 
-    return this.keywordFallbackSearch(query, 5);
+    return this.keywordFallbackSearch(query, limit);
   }
 
   keywordFallbackSearch(query, limit = 5) {
@@ -607,7 +572,7 @@ class WTFMCPManagerServer {
         if (mcp.categories && Array.isArray(mcp.categories) &&
             mcp.categories.some(cat => cat.toLowerCase().includes(keyword))) score += 2;
         if (id.includes(keyword)) score += 1;
-      });
+      }
 
       if (score > 0) {
         results.push({ id, ...mcp, score });


### PR DESCRIPTION
## Summary
- add the missing RouterClient import used by the MCP server
- simplify searchMCPs to rely on the router client with a local fallback
- make the local MCP search asynchronous and fix its keyword loop syntax

## Testing
- npm test *(fails: existing SyntaxError in lib/index.js and lib/mcp-server.js unrelated to changes)*

------
https://chatgpt.com/codex/tasks/task_e_68e1e58d39b4832694ec3e4fceab1b5a