### PR TITLE
Fix missing RouterRetriever import in MCP server

### DIFF
--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -18,6 +18,7 @@ import { DynamicMCPGenerator } from './dynamic/mcp-generator.js';
 import { APIDiscoveryService } from './discovery/api-discovery.js';
 import { VectorRouter } from './router/vector-router.js';
 import { RouterClient } from './router/client.js';
+import { RouterRetriever } from './server/retriever.js';
 
 class WTFMCPManagerServer {
   constructor(options = {}) {


### PR DESCRIPTION
## Summary
- import the RouterRetriever helper into the MCP server so the constructor can instantiate it safely

## Testing
- node lib/mcp-server.js

------
https://chatgpt.com/codex/tasks/task_e_68e1e7a1f39c83269497ca3d42357bb4