### PR TITLE
Fix RouterClient import in MCP server

### DIFF
--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -17,7 +17,7 @@ import { AutoDetector } from './detector.js';
 import { DynamicMCPGenerator } from './dynamic/mcp-generator.js';
 import { APIDiscoveryService } from './discovery/api-discovery.js';
 import { VectorRouter } from './router/vector-router.js';
-import { RouterClient } from './router/client.js';
+import RouterClient from './router/client.js';
 
 class WTFMCPManagerServer {
   constructor(options = {}) {


### PR DESCRIPTION
## Summary
- switch the RouterClient import in `lib/mcp-server.js` to use the module's default export
- ensure the constructor continues to instantiate the RouterClient using the default export

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1e7ac92248326990ce4b77254b7c1