### PR TITLE
Clarify single import set in entry module

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 /**
  * WTF-MCP-Manager Main Entry Point
+ * Each component is imported exactly once for clarity.
  */
 import { MCPManager } from './manager.js';
 import { MCPRegistry } from './registry.js';


### PR DESCRIPTION
## Summary
- document that the entry module imports each manager component only once

## Testing
- npm test *(fails: existing errors about missing MCPVectorRetriever export and RouterRetriever definition)*

------
https://chatgpt.com/codex/tasks/task_e_68e1e792deb48326b76af9a69056fe25