### PR TITLE
Remove stray shebang from vector retriever module

### DIFF
--- a/lib/router/vector-retriever.js
+++ b/lib/router/vector-retriever.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /**
  * Vector retriever for the WTF MCP router.
  * Provides utilities for embedding MCP metadata and


### PR DESCRIPTION
## Summary
- remove the leftover shell shebang so `vector-retriever.js` only contains the module implementation

## Testing
- npm test *(fails: 3 tests currently failing in the suite prior to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e1e794b5a483268870ce3c17149ba3