### PR TITLE
Refine MCP search flow

### DIFF
--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -18,6 +18,7 @@ import { DynamicMCPGenerator } from './dynamic/mcp-generator.js';
 import { APIDiscoveryService } from './discovery/api-discovery.js';
 import { VectorRouter } from './router/vector-router.js';
 import { RouterClient } from './router/client.js';
+import { RouterRetriever } from './router/retriever.js';
 
 class WTFMCPManagerServer {
   constructor(options = {}) {
@@ -505,55 +506,189 @@ class WTFMCPManagerServer {
     }
   }
 
-  async searchMCPs(query) {
+  normalizeSearchResult(rawResult, defaultSource = 'registry') {
+    if (!rawResult) {
+      return null;
+    }
+
+    const spreadable = value =>
+      (value && typeof value === 'object' && !Array.isArray(value)) ? value : {};
+
+    const merged = {
+      ...spreadable(rawResult.metadata),
+      ...spreadable(rawResult.payload),
+      ...spreadable(rawResult.tool),
+      ...spreadable(rawResult.data),
+      ...spreadable(rawResult)
+    };
+
+    const packageName = merged.package || merged.packageName || merged.pkg;
+    const coerceNumber = value => {
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        return value;
+      }
+      if (typeof value === 'string') {
+        const parsed = Number.parseFloat(value);
+        return Number.isNaN(parsed) ? null : parsed;
+      }
+      return null;
+    };
+
+    const idCandidates = [
+      merged.id,
+      rawResult?.id,
+      merged.mcpId,
+      rawResult?.mcpId,
+      packageName ? this.extractMCPId(packageName) : null
+    ].filter(Boolean);
+
+    let id = idCandidates.find(candidate => typeof candidate === 'string' && candidate.trim().length > 0);
+    if (!id && merged.name) {
+      id = merged.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+    }
+
+    if (!id) {
+      return null;
+    }
+
+    const normalizeArray = value => {
+      if (!value) {
+        return [];
+      }
+
+      if (Array.isArray(value)) {
+        return value.filter(Boolean);
+      }
+
+      if (typeof value === 'string') {
+        return value
+          .split(/[,;\n]/)
+          .map(item => item.trim())
+          .filter(Boolean);
+      }
+
+      return [];
+    };
+
+    const args = Array.isArray(merged.args)
+      ? merged.args
+      : merged.args
+        ? [merged.args]
+        : [];
+
+    const categories = normalizeArray(merged.categories || rawResult?.categories);
+    const requiredEnv = normalizeArray(merged.requiredEnv || rawResult?.requiredEnv);
+
+    const score = coerceNumber(rawResult?.score) ??
+      coerceNumber(merged.score) ??
+      coerceNumber(rawResult?.similarity) ??
+      coerceNumber(merged.similarity);
+
+    const source = merged.source || rawResult?.source || defaultSource;
+
+    return {
+      id,
+      name: merged.name || this.formatMCPName(id),
+      description: merged.description || merged.summary || '',
+      categories,
+      package: packageName || null,
+      command: merged.command || null,
+      args,
+      requiredEnv,
+      score: typeof score === 'number' ? score : 0,
+      source
+    };
+  }
+
+  async searchMCPs(query, limit = 10) {
     const sanitizedQuery = (query || '').trim();
-    const limit = 10;
+    const maxResults = Math.max(1, Math.min(limit || 10, 50));
+
+    if (!sanitizedQuery) {
+      return [];
+    }
+
+    const combinedResults = [];
+    const seen = new Set();
+
+    const pushResults = (items, defaultSource) => {
+      if (!Array.isArray(items)) {
+        return;
+      }
+
+      for (const item of items) {
+        const normalized = this.normalizeSearchResult(item, defaultSource);
+        if (!normalized) {
+          continue;
+        }
+
+        const key = normalized.id || `${normalized.name}:${normalized.source}`;
+        if (!key || seen.has(key)) {
+          continue;
+        }
+
+        seen.add(key);
+        combinedResults.push(normalized);
+
+        if (combinedResults.length >= maxResults) {
+          break;
+        }
+      }
+    };
 
     if (this.routerClient?.isConfigured) {
       try {
-        const remoteResults = await this.routerClient.query({ query: sanitizedQuery, topK: limit });
-        if (Array.isArray(remoteResults) && remoteResults.length > 0) {
-          return remoteResults;
-        }
+        const remoteResults = await this.routerClient.query({ query: sanitizedQuery, topK: maxResults });
+        pushResults(remoteResults, 'router');
       } catch (error) {
         console.warn('Router HTTP query error:', error?.message || error);
       }
     }
 
-    const localResults = await this.searchMCPsLocal(sanitizedQuery, limit);
-    if (Array.isArray(localResults) && localResults.length > 0) {
-      return localResults;
+    if (combinedResults.length < maxResults) {
+      const localResults = await this.searchMCPsLocal(sanitizedQuery, maxResults);
+      pushResults(localResults, 'local');
     }
 
-    if (sanitizedQuery && this.registryText) {
+    if (combinedResults.length < maxResults && typeof this.registry?.search === 'function') {
+      const registryResults = this.registry.search(sanitizedQuery).slice(0, maxResults);
+      pushResults(registryResults, 'registry');
+    }
+
+    if (combinedResults.length < maxResults && this.registryText) {
       const queryLower = sanitizedQuery.toLowerCase();
-      const lines = this.registryText.split('\n');
       const matches = [];
 
-      for (const line of lines) {
-        if (line.toLowerCase().includes(queryLower)) {
-          const match = line.match(/@[\w-]+\/[\w-]+|[\w-]+-mcp|mcp-[\w-]+/);
-          if (match) {
-            matches.push({
-              name: match[0],
-              description: line,
-              relevance: 'high',
-              source: 'registry'
-            });
-          }
+      for (const line of this.registryText.split('\n')) {
+        if (!line.toLowerCase().includes(queryLower)) {
+          continue;
         }
 
-        if (matches.length >= limit) {
+        const match = line.match(/@[\w-]+\/[\w.-]+|[\w-]+-mcp|mcp-[\w-]+/);
+        if (!match) {
+          continue;
+        }
+
+        const identifier = this.extractMCPId(match[0]) || match[0];
+
+        matches.push({
+          id: identifier,
+          name: this.formatMCPName(identifier),
+          description: line.trim(),
+          package: match[0],
+          source: 'registry-text',
+          score: 0.01
+        });
+
+        if (combinedResults.length + matches.length >= maxResults) {
           break;
         }
       }
 
-      if (matches.length > 0) {
-        return matches.slice(0, limit);
-      }
+      pushResults(matches, 'registry-text');
     }
 
-    return [];
+    return combinedResults.slice(0, maxResults);
   }
 
   async searchMCPsLocal(query, limit = 10) {


### PR DESCRIPTION
## Summary
- remove the redundant searchMCPs definition and replace it with a normalizer that unifies search results
- fold router, local, registry, and registry-text lookups into a single search pipeline that deduplicates and limits results
- add the missing RouterRetriever import so the MCP server boots correctly

## Testing
- node --check lib/mcp-server.js
- { cat <<'EOF'; } | node lib/mcp-server.js
{"jsonrpc":"2.0","id":1,"method":"initialize"}
{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"search_mcps","arguments":{"query":"database"}}}
EOF


------
https://chatgpt.com/codex/tasks/task_e_68e1e7a66fb88326aef32f488dde70e9