### PR TITLE
Fix MCP search fallbacks and add regression tests

### DIFF
--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -33,10 +33,6 @@ class WTFMCPManagerServer {
     this.dynamicMCPs = new Map();
     this.workflows = new Map();
     this.routerClient = new RouterClient(options.routerClientOptions || {});
-    this.routerRetriever = options.routerRetriever || new RouterRetriever({
-      registry: this.registry,
-      fallback: (query, limit) => this.searchMCPsLocal(query, limit)
-    });
   }
 
   async initialize() {
@@ -505,67 +501,57 @@ class WTFMCPManagerServer {
     }
   }
 
-  async searchMCPs(query) {
+  async searchMCPs(query, options = {}) {
     const sanitizedQuery = (query || '').trim();
-    const limit = 10;
+    const limit = Math.max(1, Math.min(options.limit || 10, 50));
+    const aggregated = [];
 
     if (this.routerClient?.isConfigured) {
       try {
         const remoteResults = await this.routerClient.query({ query: sanitizedQuery, topK: limit });
-        if (Array.isArray(remoteResults) && remoteResults.length > 0) {
-          return remoteResults;
+        if (Array.isArray(remoteResults)) {
+          for (const result of remoteResults) {
+            if (!result || !result.id) continue;
+            aggregated.push(result);
+            if (aggregated.length >= limit) break;
+          }
         }
       } catch (error) {
         console.warn('Router HTTP query error:', error?.message || error);
       }
     }
 
-    const localResults = await this.searchMCPsLocal(sanitizedQuery, limit);
-    if (Array.isArray(localResults) && localResults.length > 0) {
-      return localResults;
-    }
-
-    if (sanitizedQuery && this.registryText) {
-      const queryLower = sanitizedQuery.toLowerCase();
-      const lines = this.registryText.split('\n');
-      const matches = [];
-
-      for (const line of lines) {
-        if (line.toLowerCase().includes(queryLower)) {
-          const match = line.match(/@[\w-]+\/[\w-]+|[\w-]+-mcp|mcp-[\w-]+/);
-          if (match) {
-            matches.push({
-              name: match[0],
-              description: line,
-              relevance: 'high',
-              source: 'registry'
-            });
-          }
-        }
-
-        if (matches.length >= limit) {
-          break;
-        }
-      }
-
-      if (matches.length > 0) {
-        return matches.slice(0, limit);
+    if (aggregated.length < limit) {
+      const localResults = await this.searchMCPsLocal(sanitizedQuery, limit);
+      for (const result of localResults) {
+        if (!result || !result.id) continue;
+        if (aggregated.some(existing => existing.id === result.id)) continue;
+        aggregated.push(result);
+        if (aggregated.length >= limit) break;
       }
     }
 
-    return [];
+    if (aggregated.length < limit && sanitizedQuery) {
+      const registryResults = this.searchRegistryText(sanitizedQuery, limit);
+      for (const result of registryResults) {
+        if (!result || !result.id) continue;
+        if (aggregated.some(existing => existing.id === result.id)) continue;
+        aggregated.push(result);
+        if (aggregated.length >= limit) break;
+      }
+    }
+
+    return aggregated;
   }
 
   async searchMCPsLocal(query, limit = 10) {
-    if (!this.availableMCPs) {
-      this.availableMCPs = this.registry.getAll();
-    }
-
+    const sanitizedQuery = (query || '').trim();
     const maxResults = Math.max(1, Math.min(limit || 10, 50));
+    const availableMCPs = this.ensureLocalRegistry();
 
-    if (this.vectorRouter?.query) {
+    if (this.vectorRouter?.query && sanitizedQuery) {
       try {
-        const vectorResults = await this.vectorRouter.query(query, maxResults);
+        const vectorResults = await this.vectorRouter.query(sanitizedQuery, maxResults);
         if (Array.isArray(vectorResults) && vectorResults.length > 0) {
           return vectorResults;
         }
@@ -574,26 +560,67 @@ class WTFMCPManagerServer {
       }
     }
 
-    return this.keywordFallbackSearch(query, maxResults);
+    if (!sanitizedQuery) {
+      return Object.entries(availableMCPs)
+        .slice(0, maxResults)
+        .map(([id, mcp]) => ({ id, ...mcp, score: 1 }));
+    }
+
+    return this.keywordFallbackSearch(sanitizedQuery, maxResults, availableMCPs);
   }
 
-  keywordFallbackSearch(query, limit = 5) {
-    if (!query || !query.trim()) {
+  searchRegistryText(query, limit = 10) {
+    if (!this.registryText) {
       return [];
     }
 
-    const keywords = query.toLowerCase().split(/\s+/).filter(word => word.length > 2);
+    const matches = [];
+    const queryLower = query.toLowerCase();
+
+    for (const line of this.registryText.split('\n')) {
+      if (!line || !line.toLowerCase().includes(queryLower)) {
+        continue;
+      }
+
+      const match = line.match(/@[\w-]+\/[\w-]+|[\w-]+-mcp|mcp-[\w-]+/);
+      if (!match) {
+        continue;
+      }
+
+      matches.push({
+        id: match[0],
+        name: match[0],
+        description: line,
+        relevance: 'high',
+        source: 'registry'
+      });
+
+      if (matches.length >= limit) {
+        break;
+      }
+    }
+
+    return matches;
+  }
+
+  keywordFallbackSearch(query, limit = 5, availableMCPs = null) {
+    const sanitizedQuery = (query || '').trim();
+    if (!sanitizedQuery) {
+      return [];
+    }
+
+    const registry = availableMCPs || this.ensureLocalRegistry();
+    const keywords = sanitizedQuery.toLowerCase().split(/\s+/).filter(word => word.length > 2);
     const results = [];
 
-    for (const [id, mcp] of Object.entries(this.availableMCPs || {})) {
+    for (const [id, mcp] of Object.entries(registry)) {
       let score = 0;
 
       for (const keyword of keywords) {
         if (mcp.name && mcp.name.toLowerCase().includes(keyword)) score += 3;
         if (mcp.description && mcp.description.toLowerCase().includes(keyword)) score += 2;
-        if (mcp.categories && Array.isArray(mcp.categories) &&
-            mcp.categories.some(cat => cat.toLowerCase().includes(keyword))) score += 2;
-        if (id.includes(keyword)) score += 1;
+        if (Array.isArray(mcp.categories) && mcp.categories.some(cat => cat.toLowerCase().includes(keyword))) score += 2;
+        if (id.toLowerCase().includes(keyword)) score += 1;
       }
 
       if (score > 0) {
@@ -602,6 +629,14 @@ class WTFMCPManagerServer {
     }
 
     return results.sort((a, b) => b.score - a.score).slice(0, limit);
+  }
+
+  ensureLocalRegistry() {
+    if (!this.availableMCPs || Object.keys(this.availableMCPs).length === 0) {
+      this.availableMCPs = this.registry.getAll();
+    }
+
+    return this.availableMCPs;
   }
 
   async retrieveRelevantTools(query, limit = 5) {

--- a/test/search-mcps.test.js
+++ b/test/search-mcps.test.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { WTFMCPManagerServer } from '../lib/mcp-server.js';
+
+const stubVectorRouter = {
+  async query() {
+    return [];
+  },
+  isAvailable() {
+    return false;
+  }
+};
+
+test('searchMCPs returns router results when available', async () => {
+  const server = new WTFMCPManagerServer({ vectorRouter: stubVectorRouter });
+  server.routerClient = {
+    isConfigured: true,
+    async query({ query, topK }) {
+      assert.strictEqual(query, 'database');
+      assert.strictEqual(topK, 5);
+      return [
+        { id: 'remote-db', name: 'Remote DB', description: 'Remote database tool', source: 'router' }
+      ];
+    }
+  };
+
+  const results = await server.searchMCPs('database', { limit: 5 });
+
+  assert.ok(Array.isArray(results));
+  assert.ok(results.length > 0);
+  assert.strictEqual(results[0].id, 'remote-db');
+});
+
+test('searchMCPs falls back to local registry metadata', async () => {
+  const server = new WTFMCPManagerServer({ vectorRouter: stubVectorRouter });
+  server.routerClient = {
+    isConfigured: true,
+    async query() {
+      return [];
+    }
+  };
+
+  const results = await server.searchMCPs('database', { limit: 5 });
+
+  assert.ok(results.some(result => result.id === 'supabase'));
+});
+
+test('searchMCPs falls back to registry text when needed', async () => {
+  const server = new WTFMCPManagerServer({ vectorRouter: stubVectorRouter });
+  server.routerClient = {
+    isConfigured: true,
+    async query() {
+      return [];
+    }
+  };
+
+  server.registry.getAll = () => ({ });
+  server.availableMCPs = {};
+  server.registryText = '@example/custom-mcp Useful custom integration';
+
+  const results = await server.searchMCPs('custom', { limit: 3 });
+
+  assert.ok(results.some(result => result.id === '@example/custom-mcp'));
+});


### PR DESCRIPTION
## Summary
- consolidate `searchMCPs` so router, local registry, and registry-text fallbacks return a single result set without undefined helpers
- harden local keyword fallback by normalizing registry access and add a helper to reuse built-in metadata when remote data is unavailable
- add automated coverage that exercises router, local, and registry-text search fallbacks

## Testing
- npm test *(fails: test/retriever.test.js expects MCPVectorRetriever export)*
- node --test test/search-mcps.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e1e7aecb60832690b749b1ef2ff7e1