### PR TITLE
Fix MCP server search fallback initialization

### DIFF
--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -18,6 +18,14 @@ import { DynamicMCPGenerator } from './dynamic/mcp-generator.js';
 import { APIDiscoveryService } from './discovery/api-discovery.js';
 import { VectorRouter } from './router/vector-router.js';
 import { RouterClient } from './router/client.js';
+import { RouterRetriever } from './server/retriever.js';
+
+const DefaultVectorStoreUnavailableError = class VectorStoreUnavailableError extends Error {
+  constructor(message = 'Vector store is unavailable') {
+    super(message);
+    this.name = 'VectorStoreUnavailableError';
+  }
+};
 
 class WTFMCPManagerServer {
   constructor(options = {}) {
@@ -37,6 +45,9 @@ class WTFMCPManagerServer {
       registry: this.registry,
       fallback: (query, limit) => this.searchMCPsLocal(query, limit)
     });
+    this.toolRetriever = options.toolRetriever || null;
+    this.retriever = options.retriever || this.routerRetriever;
+    this.VectorStoreUnavailableError = options.VectorStoreUnavailableError || DefaultVectorStoreUnavailableError;
   }
 
   async initialize() {
@@ -589,11 +600,22 @@ class WTFMCPManagerServer {
       let score = 0;
 
       for (const keyword of keywords) {
-        if (mcp.name && mcp.name.toLowerCase().includes(keyword)) score += 3;
-        if (mcp.description && mcp.description.toLowerCase().includes(keyword)) score += 2;
+        if (mcp.name && mcp.name.toLowerCase().includes(keyword)) {
+          score += 3;
+        }
+
+        if (mcp.description && mcp.description.toLowerCase().includes(keyword)) {
+          score += 2;
+        }
+
         if (mcp.categories && Array.isArray(mcp.categories) &&
-            mcp.categories.some(cat => cat.toLowerCase().includes(keyword))) score += 2;
-        if (id.includes(keyword)) score += 1;
+            mcp.categories.some(cat => cat.toLowerCase().includes(keyword))) {
+          score += 2;
+        }
+
+        if (id.includes(keyword)) {
+          score += 1;
+        }
       }
 
       if (score > 0) {


### PR DESCRIPTION
## Summary
- import the RouterRetriever and expose optional collaborators on the MCP server to avoid missing dependency errors
- provide a default VectorStoreUnavailableError helper so callers can inject or use the built-in type
- tidy the keywordFallbackSearch loop to remove the stray closing token and clarify the scoring logic

## Testing
- node --check lib/mcp-server.js
- node -e "import('./lib/mcp-server.js').then(async ({WTFMCPManagerServer})=>{const server=new WTFMCPManagerServer(); const results=await server.searchMCPs('database'); console.log('results', Array.isArray(results), results.length);}).catch(err=>{console.error(err); process.exitCode=1;});"


------
https://chatgpt.com/codex/tasks/task_e_68e1e7a776748326a4aaace525dbf1b5