### PR TITLE
feat: generate dynamic tools with live API calls

### DIFF
--- a/lib/dynamic/mcp-generator.js
+++ b/lib/dynamic/mcp-generator.js
@@ -255,7 +255,7 @@ if __name__ == "__main__":
 
     // Create package.json or requirements.txt
     if (template.language === 'javascript') {
-      await this.createPackageJson(mcpDir, apiSpec);
+      await this.createPackageJson(mcpDir, apiSpec, template.type);
     } else if (template.language === 'python') {
       await this.createRequirementsTxt(mcpDir, apiSpec);
     }
@@ -300,6 +300,7 @@ if __name__ == "__main__":
 
     // Generate tools from endpoints
     const tools = this.generateTools(apiSpec, template.type);
+    code = code.replace(/{{IMPORTS}}/g, this.generateImports(template.type));
     code = code.replace(/{{TOOLS_SETUP}}/g, tools.setup);
     code = code.replace(/{{REQUEST_HANDLERS}}/g, tools.handlers);
     code = code.replace(/{{TOOL_METHODS}}/g, tools.methods);
@@ -349,29 +350,246 @@ if __name__ == "__main__":
   }
 
   generateToolMethod(templateType, toolName, endpoint = {}) {
-    const method = (endpoint.method || 'GET').toUpperCase();
-    const path = endpoint.path || '/';
-
     if (templateType === 'graphql') {
-      const operationName = endpoint.operationName || endpoint.name || toolName;
-      return `  async ${toolName}(params = {}) {
-    return {
-      success: true,
-      message: 'Stub GraphQL operation ${operationName}',
-      operation: '${operationName}',
-      received: params
-    };
-  }`;
+      return this.generateGraphQLToolMethod(toolName, endpoint);
     }
 
-    return `  async ${toolName}(params = {}) {
-    return {
-      success: true,
-      message: '${method} ${path} stub response',
-      endpoint: { method: '${method}', path: '${path}' },
-      received: params
-    };
-  }`;
+    return this.generateRESTToolMethod(toolName, endpoint);
+  }
+
+  generateRESTToolMethod(toolName, endpoint = {}) {
+    const method = (endpoint.method || 'GET').toUpperCase();
+    const requiredParams = endpoint.parameters?.required || [];
+    const path = endpoint.path || '/';
+    const pathParams = this.extractPathParams(path);
+
+    const lines = [];
+    lines.push(`  async ${toolName}(params = {}) {`);
+
+    if (requiredParams.length > 0) {
+      lines.push(`    const requiredParams = ${JSON.stringify(requiredParams)};`);
+      lines.push('    for (const key of requiredParams) {');
+      lines.push('      if (params[key] === undefined || params[key] === null) {');
+      lines.push('        throw new Error(`Missing required parameter: ${key}`);');
+      lines.push('      }');
+      lines.push('    }');
+    }
+
+    lines.push(`    const method = '${method}';`);
+    lines.push(`    const pathTemplate = ${JSON.stringify(path)};`);
+    lines.push(`    const pathParams = ${JSON.stringify(pathParams)};`);
+    lines.push('    let resolvedPath = pathTemplate;');
+    lines.push('');
+    lines.push('    for (const param of pathParams) {');
+    lines.push('      const value = params[param];');
+      lines.push('      if (value === undefined || value === null) {');
+      lines.push('        throw new Error(`Missing required path parameter: ${param}`);');
+      lines.push('      }');
+    lines.push('      resolvedPath = resolvedPath.replace(`{${param}}`, encodeURIComponent(String(value)));');
+    lines.push('    }');
+    lines.push('');
+    lines.push("    const baseUrl = this.apiBase || '';");
+    lines.push("    if (!pathTemplate.startsWith('http') && !baseUrl) {");
+    lines.push("      throw new Error('No API base URL configured for this tool');");
+    lines.push('    }');
+    lines.push('');
+    lines.push("    const target = pathTemplate.startsWith('http')");
+    lines.push('      ? pathTemplate');
+    lines.push("      : `${baseUrl.replace(/\\\/$/, '')}/${resolvedPath.replace(/^\\\//, '')}`;");
+    lines.push('    const url = new URL(target);');
+    lines.push('');
+    lines.push('    const queryParams = new URLSearchParams();');
+    lines.push('    const bodyPayload = {};');
+    lines.push("    const hasBody = !['GET', 'DELETE'].includes(method);");
+    lines.push('');
+    lines.push('    for (const [key, value] of Object.entries(params)) {');
+    lines.push('      if (value === undefined || value === null) continue;');
+    lines.push('      if (pathParams.includes(key)) continue;');
+    lines.push('');
+    lines.push('      if (!hasBody) {');
+    lines.push('        queryParams.append(key, value);');
+    lines.push('      } else {');
+    lines.push('        bodyPayload[key] = value;');
+    lines.push('      }');
+    lines.push('    }');
+    lines.push('');
+    lines.push('    const queryString = queryParams.toString();');
+    lines.push('    if (queryString) {');
+    lines.push('      url.search = queryString;');
+    lines.push('    }');
+    lines.push('');
+    lines.push(`    const headers = Object.assign({ Accept: 'application/json' }, ${JSON.stringify(endpoint.headers || {})});`);
+    lines.push('    const requestOptions = { method, headers };');
+    lines.push('');
+    lines.push('    if (hasBody && Object.keys(bodyPayload).length > 0) {');
+    lines.push("      headers['Content-Type'] = 'application/json';");
+    lines.push('      requestOptions.body = JSON.stringify(bodyPayload);');
+    lines.push('    }');
+    lines.push('');
+    lines.push('    const response = await fetch(url.toString(), requestOptions);');
+    lines.push("    const contentType = response.headers.get('content-type') || '';");
+    lines.push('    let data;');
+    lines.push('');
+    lines.push("    if (contentType.includes('application/json')) {");
+    lines.push('      data = await response.json();');
+    lines.push('    } else {');
+    lines.push('      data = await response.text();');
+    lines.push('    }');
+    lines.push('');
+    lines.push('    if (!response.ok) {');
+    lines.push("      const detail = typeof data === 'string' ? data : JSON.stringify(data);");
+    lines.push('      throw new Error(`Request failed with status ${response.status}: ${detail}`);');
+    lines.push('    }');
+    lines.push('');
+    lines.push('    return data;');
+    lines.push('  }');
+
+    return lines.join('\n');
+  }
+
+  generateGraphQLToolMethod(toolName, endpoint = {}) {
+    const requiredParams = endpoint.parameters?.required || [];
+    const paramProperties = Object.keys(endpoint.parameters?.properties || {});
+    const operationName = endpoint.operationName || endpoint.name || toolName;
+    const operationType = (endpoint.operationType || endpoint.type || 'query').toLowerCase();
+    const document = this.buildGraphQLDocument(endpoint, operationName, operationType);
+
+    const lines = [];
+    lines.push(`  async ${toolName}(params = {}) {`);
+
+    if (requiredParams.length > 0) {
+      lines.push(`    const requiredParams = ${JSON.stringify(requiredParams)};`);
+      lines.push('    for (const key of requiredParams) {');
+      lines.push('      if (params[key] === undefined || params[key] === null) {');
+      lines.push('        throw new Error(`Missing required parameter: ${key}`);');
+      lines.push('      }');
+      lines.push('    }');
+    }
+
+    lines.push('    const variables = {};');
+    if (paramProperties.length > 0) {
+      lines.push(`    const parameterKeys = ${JSON.stringify(paramProperties)};`);
+      lines.push('    for (const key of parameterKeys) {');
+      lines.push('      const value = params[key];');
+      lines.push('      if (value !== undefined && value !== null) {');
+      lines.push('        variables[key] = value;');
+      lines.push('      }');
+      lines.push('    }');
+    }
+
+    lines.push(`    const document = ${document};`);
+    lines.push('');
+    lines.push('    if (!document) {');
+    lines.push("      throw new Error('No GraphQL document available for this tool');");
+    lines.push('    }');
+    lines.push('');
+    lines.push('    return await this.executeGraphQL(document, variables);');
+    lines.push('  }');
+
+    return lines.join('\n');
+  }
+
+  buildGraphQLDocument(endpoint, operationName, operationType) {
+    const rawDocument = endpoint.query || endpoint.document || endpoint.operation || endpoint.mutation || '';
+
+    if (rawDocument) {
+      return JSON.stringify(rawDocument);
+    }
+
+    const rootField = endpoint.rootField || endpoint.field || operationName;
+    const variableDefinitions = this.buildGraphQLVariableDefinitions(endpoint);
+    const variableUsages = this.buildGraphQLVariableUsages(endpoint);
+    const selectionSet = this.buildGraphQLSelection(endpoint);
+
+    const operation = (operationType || 'query').toLowerCase();
+    const definition = variableDefinitions ? `(${variableDefinitions})` : '';
+    const usage = variableUsages ? `(${variableUsages})` : '';
+    const selection = selectionSet ? ` {\n${selectionSet}\n  }` : '';
+    const document = `${operation} ${operationName}${definition} {\n  ${rootField}${usage}${selection}\n}`;
+
+    return JSON.stringify(document);
+  }
+
+  buildGraphQLVariableDefinitions(endpoint) {
+    const properties = endpoint.parameters?.properties || {};
+    const required = new Set(endpoint.parameters?.required || []);
+    const definitions = [];
+
+    for (const [name, schema] of Object.entries(properties)) {
+      const type = this.mapJSONTypeToGraphQL(schema.type, schema);
+      if (!type) continue;
+      const nullable = required.has(name) ? '!' : '';
+      definitions.push(`$${name}: ${type}${nullable}`);
+    }
+
+    return definitions.join(', ');
+  }
+
+  buildGraphQLVariableUsages(endpoint) {
+    const properties = endpoint.parameters?.properties || {};
+    const usages = Object.keys(properties).map(name => `${name}: $${name}`);
+    return usages.join(', ');
+  }
+
+  buildGraphQLSelection(endpoint) {
+    let selection = [];
+
+    if (Array.isArray(endpoint.selectionSet)) {
+      selection = endpoint.selectionSet;
+    } else if (typeof endpoint.selectionSet === 'string' && endpoint.selectionSet.trim()) {
+      selection = endpoint.selectionSet.split('\n');
+    } else if (Array.isArray(endpoint.fields)) {
+      selection = endpoint.fields;
+    }
+
+    if (selection.length === 0) {
+      selection = ['__typename'];
+    }
+
+    return selection
+      .map(line => line.trim())
+      .filter(Boolean)
+      .map(line => `    ${line}`)
+      .join('\n');
+  }
+
+  mapJSONTypeToGraphQL(type, schema = {}) {
+    if (schema.graphqlType) {
+      return schema.graphqlType;
+    }
+
+    switch (type) {
+      case 'string':
+        return 'String';
+      case 'integer':
+        return 'Int';
+      case 'number':
+        return 'Float';
+      case 'boolean':
+        return 'Boolean';
+      case 'array':
+        const itemType = this.mapJSONTypeToGraphQL(schema.items?.type, schema.items || {});
+        return itemType ? `[${itemType}!]` : null;
+      case 'object':
+        return 'JSON';
+      default:
+        return null;
+    }
+  }
+
+  extractPathParams(path = '') {
+    const matches = Array.from(path.matchAll(/\{([^}]+)\}/g));
+    return matches.map(match => match[1]);
+  }
+
+  generateImports(templateType) {
+    switch (templateType) {
+      case 'rest':
+      case 'rest-api':
+        return "import fetch from 'node-fetch';";
+      default:
+        return '';
+    }
   }
 
   generateResources(apiSpec) {
@@ -466,7 +684,15 @@ async def ${funcName}(${this.generateParams(endpoint.parameters)}):
     return `${clean}-${hash}`;
   }
 
-  async createPackageJson(mcpDir, apiSpec) {
+  async createPackageJson(mcpDir, apiSpec, templateType = 'rest') {
+    const dependencies = {
+      'node-fetch': '^3.0.0'
+    };
+
+    if (templateType === 'graphql' || apiSpec.graphql) {
+      dependencies['graphql-request'] = '^6.1.0';
+    }
+
     const packageJson = {
       name: `${apiSpec.name}-mcp`,
       version: "1.0.0",
@@ -476,9 +702,7 @@ async def ${funcName}(${this.generateParams(endpoint.parameters)}):
       scripts: {
         start: "node server.js"
       },
-      dependencies: {
-        "node-fetch": "^3.0.0"
-      }
+      dependencies
     };
 
     await fs.writeFile(

--- a/lib/templates/graphql.js.template
+++ b/lib/templates/graphql.js.template
@@ -6,6 +6,7 @@
  * Type: GraphQL API MCP
  */
 
+{{IMPORTS}}
 import { GraphQLClient } from 'graphql-request';
 
 class {{CLASS_NAME}}MCPServer {

--- a/lib/templates/rest-api.js.template
+++ b/lib/templates/rest-api.js.template
@@ -6,6 +6,8 @@
  * Type: REST API
  */
 
+{{IMPORTS}}
+
 class {{CLASS_NAME}}MCPServer {
   constructor() {
     this.apiBase = '{{API_BASE}}';


### PR DESCRIPTION
## Summary
- update the MCP generator to emit REST tools that build URLs, send fetch requests, and return parsed responses
- add GraphQL tool generation that builds operation documents, passes variables to GraphQLClient, and supports selection sets
- extend templates and package scaffolding to provide required imports and dependencies for the generated servers

## Testing
- `npm test` *(fails: existing retriever/vector-router suites reference missing exports and RouterRetriever)*

------
https://chatgpt.com/codex/tasks/task_e_68e1e796285c8326b6e64d9367f6783f