### PR TITLE
Enable dynamic MCPs to proxy upstream API calls

### DIFF
--- a/lib/dynamic/mcp-generator.js
+++ b/lib/dynamic/mcp-generator.js
@@ -349,27 +349,132 @@ if __name__ == "__main__":
   }
 
   generateToolMethod(templateType, toolName, endpoint = {}) {
-    const method = (endpoint.method || 'GET').toUpperCase();
-    const path = endpoint.path || '/';
-
     if (templateType === 'graphql') {
       const operationName = endpoint.operationName || endpoint.name || toolName;
+      const document = endpoint.document || endpoint.query || endpoint.mutation || endpoint.operation;
+      const defaultVariables = endpoint.variables ? JSON.stringify(endpoint.variables, null, 6) : null;
+
+      if (document) {
+        const escapedDocument = this.escapeBackticks(document);
+        return `  async ${toolName}(params = {}) {
+    const query = params.query || \`${escapedDocument}\`;
+    const variables = params.variables || ${defaultVariables || '{}'};
+    const response = await this.executeGraphQL(query, variables);
+    return { success: true, data: response };
+  }`;
+      }
+
       return `  async ${toolName}(params = {}) {
-    return {
-      success: true,
-      message: 'Stub GraphQL operation ${operationName}',
-      operation: '${operationName}',
-      received: params
-    };
+    if (!params.query) {
+      throw new Error('No GraphQL query provided for ${operationName}. Pass { query, variables? } to the tool.');
+    }
+    const variables = params.variables || ${defaultVariables || '{}'};
+    const response = await this.executeGraphQL(params.query, variables);
+    return { success: true, data: response };
   }`;
     }
 
+    const method = (endpoint.method || 'GET').toUpperCase();
+    const path = endpoint.path || '/';
+    const pathParams = Array.from(path.matchAll(/\{([^}]+)\}/g)).map(match => match[1]);
+    const pathParamSet = new Set(pathParams);
+    const paramProperties = endpoint.parameters?.properties || {};
+    const allParamNames = Object.keys(paramProperties);
+    const hasBody = !['GET', 'DELETE'].includes(method);
+
+    const explicitQuery = Array.isArray(endpoint.queryParameters)
+      ? endpoint.queryParameters
+      : null;
+
+    const queryParamNames = explicitQuery
+      ? explicitQuery.map(name => String(name))
+      : (hasBody ? [] : allParamNames.filter(name => !pathParamSet.has(name)));
+    const reservedParams = new Set([...pathParamSet, ...queryParamNames, 'body', 'query', 'headers']);
+
+    const validations = pathParams
+      .map(name => `    if (params['${name}'] === undefined) {
+      throw new Error('Missing required path parameter: ${name}');
+    }`)
+      .join('\n');
+
+    const pathExpression = '`' + path.replace(/\{([^}]+)\}/g, (_, name) => '${encodeURIComponent(params[\'' + name + '\'])}') + '`';
+
+    const queryAssignments = queryParamNames
+      .map(name => `    if (params['${name}'] !== undefined) {
+      queryParams.append('${name}', params['${name}']);
+    }`)
+      .join('\n');
+
+    const queryExtras = `    if (params.query && typeof params.query === 'object') {
+      for (const [key, value] of Object.entries(params.query)) {
+        if (value !== undefined && value !== null) {
+          queryParams.append(String(key), value);
+        }
+      }
+    }`;
+
+    let bodyBuilder = '';
+    if (hasBody) {
+      bodyBuilder = `    let bodyPayload = params.body !== undefined ? params.body : Object.keys(params).reduce((acc, key) => {
+      if (!${JSON.stringify(Array.from(reservedParams))}.includes(key)) {
+        acc[key] = params[key];
+      }
+      return acc;
+    }, {});
+    if (bodyPayload && Object.keys(bodyPayload).length === 0) {
+      bodyPayload = undefined;
+    }`;
+    }
+
+    const requestLines = [
+      `    const headers = { 'accept': 'application/json'${hasBody ? ", 'content-type': 'application/json'" : ''} };`,
+      "    const requestOptions = {",
+      `      method: '${method}',`,
+      '      headers'
+    ];
+
+    if (hasBody) {
+      requestLines.push('    };');
+      requestLines.push('    if (bodyPayload !== undefined) {');
+      requestLines.push('      requestOptions.body = JSON.stringify(bodyPayload);');
+      requestLines.push('    }');
+    } else {
+      requestLines.push('    };');
+    }
+
+    requestLines.push('    const response = await fetch(url.toString(), requestOptions);');
+    const requestInit = requestLines.join('\n');
+
+    const headerCustomization = `    if (params.headers && typeof params.headers === 'object') {
+      for (const [header, value] of Object.entries(params.headers)) {
+        if (value !== undefined) {
+          headers[String(header)] = value;
+        }
+      }
+    }`;
+
     return `  async ${toolName}(params = {}) {
+${validations ? validations + '\n' : ''}    if (!this.apiBase) {
+      throw new Error('API base URL is not configured for this tool.');
+    }
+    const url = new URL(${pathExpression}, this.apiBase);
+    const queryParams = new URLSearchParams();
+${queryAssignments ? queryAssignments + '\n' : ''}${queryExtras}\n    const queryString = queryParams.toString();
+    if (queryString) {
+      url.search = queryString;
+    }
+${hasBody ? bodyBuilder + '\n' : ''}${headerCustomization}\n${requestInit}
+    const contentType = response.headers.get('content-type') || '';
+    const responseData = contentType.includes('application/json') ? await response.json() : await response.text();
+    if (!response.ok) {
+      const errorDetail = typeof responseData === 'string' ? responseData : JSON.stringify(responseData);
+      throw new Error('Upstream ${method} ${path} failed: ' + response.status + ' ' + response.statusText + ' - ' + errorDetail);
+    }
     return {
       success: true,
-      message: '${method} ${path} stub response',
-      endpoint: { method: '${method}', path: '${path}' },
-      received: params
+      status: response.status,
+      headers: Object.fromEntries(response.headers.entries()),
+      data: responseData
     };
   }`;
   }
@@ -399,32 +504,101 @@ if __name__ == "__main__":
     if (apiSpec.endpoints) {
       apiSpec.endpoints.forEach(endpoint => {
         const method = endpoint.method?.toLowerCase() || 'get';
-        const funcName = this.endpointToToolName(endpoint);
+        const rawPath = endpoint.path || '/';
+        const pathParams = Array.from(rawPath.matchAll(/\{([^}]+)\}/g)).map(match => match[1]);
+        const pathParamMap = {};
+        pathParams.forEach(name => {
+          pathParamMap[name] = this.toPythonIdentifier(name);
+        });
 
-        endpoints.push(`
-@app.${method}("${endpoint.path}")
-async def ${funcName}(${this.generateParams(endpoint.parameters)}):
-    """${endpoint.description || ''}"""
-    # Generated endpoint implementation
-    return {"message": "Generated endpoint for ${endpoint.path}"}`);
+        const pythonPath = rawPath.replace(/\{([^}]+)\}/g, (_, name) => `{${pathParamMap[name] || this.toPythonIdentifier(name)}}`);
+        const funcName = this.endpointToToolName(endpoint);
+        const paramsInfo = this.generateParams(endpoint.parameters, method, pathParamMap);
+        const description = (endpoint.description || '').replace(/"""/g, '\\"\\"\\"');
+
+        const pathParamSet = new Set(pathParams);
+        const nonPathEntries = paramsInfo.entries.filter(entry => !pathParamSet.has(entry.original));
+        const isQueryMethod = ['get', 'delete'].includes(method);
+        const queryEntries = isQueryMethod ? nonPathEntries : [];
+        const bodyEntries = !isQueryMethod ? nonPathEntries : [];
+
+        const lines = [];
+        lines.push(`@app.${method}("${pythonPath}")`);
+        lines.push(`async def ${funcName}(${paramsInfo.signature}):`);
+        lines.push(`    """${description}"""`);
+        lines.push(`    upstream_path = f"${pythonPath}"`);
+        lines.push('    query_params: Dict[str, Any] = {}');
+
+        queryEntries.forEach(entry => {
+          lines.push(`    if ${entry.python} is not None:`);
+          lines.push(`        query_params["${entry.original}"] = ${entry.python}`);
+        });
+
+        lines.push('    request_kwargs = {"params": query_params or None}');
+
+        if (paramsInfo.hasBody) {
+          lines.push('    body_payload = dict(payload) if isinstance(payload, dict) else {}');
+          bodyEntries.forEach(entry => {
+            lines.push(`    if ${entry.python} is not None:`);
+            lines.push(`        body_payload["${entry.original}"] = ${entry.python}`);
+          });
+          lines.push('    if body_payload:');
+          lines.push('        request_kwargs["json"] = body_payload');
+          lines.push('    elif isinstance(payload, dict):');
+          lines.push('        request_kwargs["json"] = payload');
+          lines.push('    elif payload is not None:');
+          lines.push('        request_kwargs["content"] = payload');
+        }
+
+        lines.push('    try:');
+        lines.push('        async with httpx.AsyncClient(base_url=API_BASE, timeout=30.0) as client:');
+        lines.push(`            response = await client.request("${method.toUpperCase()}", upstream_path, **request_kwargs)`);
+        lines.push('        response.raise_for_status()');
+        lines.push('    except httpx.HTTPStatusError as exc:');
+        lines.push('        raise HTTPException(status_code=exc.response.status_code, detail={"error": "Upstream request failed", "details": exc.response.text})');
+        lines.push('    except httpx.RequestError as exc:');
+        lines.push('        raise HTTPException(status_code=502, detail={"error": "Upstream request failed", "details": str(exc)})');
+        lines.push('    return Response(content=response.text, media_type=response.headers.get("content-type", "application/json"), status_code=response.status_code)');
+
+        endpoints.push(lines.join('\n'));
       });
     }
 
-    return endpoints.join('\n');
+    return endpoints.join('\n\n');
   }
 
-  generateParams(parameters) {
-    if (!parameters || Object.keys(parameters).length === 0) {
-      return '';
-    }
+  generateParams(parameters, method = 'get', pathParamMap = {}) {
+    const entries = [];
 
-    return Object.entries(parameters.properties || {})
-      .map(([name, schema]) => {
+    if (parameters && parameters.properties) {
+      Object.entries(parameters.properties).forEach(([name, schema]) => {
+        const pythonName = pathParamMap[name] || this.toPythonIdentifier(name);
         const type = this.schemaTypeToPython(schema.type);
         const required = parameters.required?.includes(name);
-        return required ? `${name}: ${type}` : `${name}: ${type} = None`;
-      })
-      .join(', ');
+        entries.push({ original: name, python: pythonName, required, type });
+      });
+    }
+
+    Object.entries(pathParamMap).forEach(([original, python]) => {
+      if (!entries.some(entry => entry.original === original)) {
+        entries.unshift({ original, python, required: true, type: 'str' });
+      }
+    });
+
+    const signatureParts = entries.map(entry => (
+      entry.required ? `${entry.python}: ${entry.type}` : `${entry.python}: ${entry.type} = None`
+    ));
+
+    const hasBody = !['get', 'delete'].includes(method);
+    if (hasBody) {
+      signatureParts.push('payload: Dict[str, Any] = Body(None)');
+    }
+
+    return {
+      signature: signatureParts.join(', '),
+      entries,
+      hasBody
+    };
   }
 
   schemaTypeToPython(type) {
@@ -437,6 +611,21 @@ async def ${funcName}(${this.generateParams(endpoint.parameters)}):
       'object': 'dict'
     };
     return typeMap[type] || 'Any';
+  }
+
+  toPythonIdentifier(name) {
+    if (!name) return 'param';
+    const cleaned = name.replace(/[^a-zA-Z0-9_]/g, '_');
+    const normalized = cleaned.replace(/_{2,}/g, '_').replace(/^_+|_+$/g, '');
+    const identifier = normalized || 'param';
+    if (/^[0-9]/.test(identifier)) {
+      return `param_${identifier}`;
+    }
+    return identifier;
+  }
+
+  escapeBackticks(str = '') {
+    return String(str).replace(/`/g, '\\`');
   }
 
   endpointToToolName(endpoint) {
@@ -477,7 +666,8 @@ async def ${funcName}(${this.generateParams(endpoint.parameters)}):
         start: "node server.js"
       },
       dependencies: {
-        "node-fetch": "^3.0.0"
+        "node-fetch": "^3.0.0",
+        "graphql-request": "^6.1.0"
       }
     };
 
@@ -492,7 +682,7 @@ async def ${funcName}(${this.generateParams(endpoint.parameters)}):
       'fastapi>=0.100.0',
       'fastapi-mcp>=1.0.0',
       'uvicorn>=0.23.0',
-      'requests>=2.31.0'
+      'httpx>=0.25.0'
     ];
 
     await fs.writeFile(

--- a/lib/templates/fastapi.py.template
+++ b/lib/templates/fastapi.py.template
@@ -5,12 +5,13 @@ Created: {{TIMESTAMP}}
 Type: FastAPI MCP Server
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Body, Response
 from fastapi_mcp import FastApiMCP
-from pydantic import BaseModel
-from typing import Optional, List, Dict, Any
+from typing import Dict, Any
 import os
-import json
+import httpx
+
+API_BASE = "{{API_BASE}}"
 
 # Create FastAPI app
 app = FastAPI(

--- a/lib/templates/graphql.js.template
+++ b/lib/templates/graphql.js.template
@@ -37,10 +37,10 @@ class {{CLASS_NAME}}MCPServer {
 
   async executeGraphQL(query, variables = {}) {
     try {
-      const result = await this.client.request(query, variables);
-      return { success: true, data: result };
+      return await this.client.request(query, variables);
     } catch (error) {
-      return { success: false, error: error.message };
+      const details = error?.response?.errors ? JSON.stringify(error.response.errors) : error.message;
+      throw new Error(`GraphQL request failed: ${details}`);
     }
   }
 

--- a/lib/templates/rest-api.js.template
+++ b/lib/templates/rest-api.js.template
@@ -6,6 +6,12 @@
  * Type: REST API
  */
 
+import fetch from 'node-fetch';
+
+if (!globalThis.fetch) {
+  globalThis.fetch = fetch;
+}
+
 class {{CLASS_NAME}}MCPServer {
   constructor() {
     this.apiBase = '{{API_BASE}}';

--- a/test/test-dynamic-generation.js
+++ b/test/test-dynamic-generation.js
@@ -7,6 +7,8 @@
 import { DynamicMCPGenerator } from '../lib/dynamic/mcp-generator.js';
 import { APIDiscoveryService } from '../lib/discovery/api-discovery.js';
 import chalk from 'chalk';
+import http from 'node:http';
+import assert from 'node:assert';
 
 async function testDynamicGeneration() {
   console.log(chalk.cyan('\n🧪 Testing Dynamic MCP Generation System\n'));
@@ -129,6 +131,82 @@ async function testDynamicGeneration() {
     console.log(chalk.green(`✅ ${passed}/${apiTypes.length} API types detected correctly`));
   } catch (error) {
     console.log(chalk.red('❌ API type detection failed:'), error.message);
+  }
+
+  // Test 7: Generated tool makes upstream HTTP request
+  console.log(chalk.yellow('\n7. Testing generated tool HTTP forwarding...'));
+  let server;
+  try {
+    const fetchImpl = global.fetch || (await import('node-fetch')).default;
+    if (!global.fetch) {
+      global.fetch = fetchImpl;
+    }
+
+    const receivedRequests = [];
+    server = http.createServer((req, res) => {
+      let body = '';
+      req.on('data', chunk => {
+        body += chunk;
+      });
+      req.on('end', () => {
+        receivedRequests.push({
+          method: req.method,
+          url: req.url,
+          body: body ? JSON.parse(body) : null,
+          headers: req.headers
+        });
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true }));
+      });
+    });
+
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    const { port } = server.address();
+    const baseUrl = `http://127.0.0.1:${port}`;
+
+    const endpointSpec = {
+      path: '/echo',
+      method: 'POST',
+      description: 'Echo payload back',
+      parameters: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', description: 'Identifier' },
+          message: { type: 'string', description: 'Message to echo' }
+        },
+        required: ['id']
+      }
+    };
+
+    const toolName = generator.endpointToToolName(endpointSpec);
+    const methodSource = generator.generateToolMethod('rest', toolName, endpointSpec);
+    const ToolClass = new Function(`
+return class GeneratedTool {
+  constructor() {
+    this.apiBase = ${JSON.stringify(baseUrl)};
+  }
+${methodSource}
+};
+    `)();
+
+    const toolInstance = new ToolClass();
+    const result = await toolInstance[toolName]({ id: 'abc', message: 'hello world' });
+
+    assert.strictEqual(receivedRequests.length, 1, 'Upstream service did not receive a request');
+    const [requestDetails] = receivedRequests;
+    assert.strictEqual(requestDetails.method, 'POST');
+    assert.ok(requestDetails.url.startsWith('/echo'));
+    assert.deepStrictEqual(requestDetails.body, { id: 'abc', message: 'hello world' });
+    assert.strictEqual(result.status, 200);
+    assert.deepStrictEqual(result.data, { ok: true });
+
+    console.log(chalk.green('✅ Generated tool forwarded request to upstream service'));
+  } catch (error) {
+    console.log(chalk.red('❌ Generated tool forwarding failed:'), error.message);
+  } finally {
+    if (server) {
+      await new Promise(resolve => server.close(resolve));
+    }
   }
 
   console.log(chalk.cyan('\n🎯 Dynamic MCP generation tests completed!\n'));


### PR DESCRIPTION
## Summary
- teach the dynamic generator to emit REST tools that call upstream services via fetch and GraphQL tools that delegate to executeGraphQL with real queries
- generate FastAPI routes that proxy to upstream APIs with httpx and update templates to import the new dependencies and surface detailed errors
- extend the dynamic generation test suite with a mock HTTP service to assert generated tools actually reach the upstream API

## Testing
- npm test -- test/test-dynamic-generation.js *(fails: upstream retriever/vector-router tests require RouterRetriever export)*
- node test/test-dynamic-generation.js


------
https://chatgpt.com/codex/tasks/task_e_68e1e78d96e88326ac132d2967a11d5e