### PR TITLE
Refactor registry parsing reuse

### DIFF
--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -174,14 +174,15 @@ class WTFMCPManagerServer {
 
       const parsedRegistry = this.parseMCPRegistry(text);
       this.availableMCPs = parsedRegistry;
+
+      const normalizedRecords = this.normalizeRegistryRecords(Object.values(parsedRegistry));
+      this.registryToolRecords = normalizedRecords;
+
       await this.updateVectorIndexFromRegistry(parsedRegistry, { force: true });
 
       // Don't parse - just return the raw text for Claude to analyze
       this.lastFetchTime = now;
       this.registryText = text;
-
-      const normalizedRecords = this.normalizeRegistryRecords(Object.values(parsedRegistry));
-      this.registryToolRecords = normalizedRecords;
 
       const dataHash = createHash('sha256').update(text).digest('hex');
       const shouldIndex = force || this.registryIndexHash !== dataHash || this.vectorRouter.available === false;


### PR DESCRIPTION
## Summary
- reuse the parsed registry result when computing normalized records
- populate `registryToolRecords` before updating the vector index to avoid redundant parsing

## Testing
- node --check lib/mcp-server.js

------
https://chatgpt.com/codex/tasks/task_e_68e1e7a3fd748326add6af0b8be92454