### PR TITLE
Handle vector router availability during registry ingestion

### DIFF
--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -189,12 +189,17 @@ class WTFMCPManagerServer {
       this.registryText = text;
 
       const dataHash = createHash('sha256').update(text).digest('hex');
-      const shouldIndex = force || this.registryIndexHash !== dataHash || this.vectorRouter.available === false;
-      let indexed = false;
+      const shouldIndex = force || this.registryIndexHash !== dataHash || !this.vectorRouter.isAvailable?.();
+      let ingestionResult = null;
 
       if (shouldIndex && normalizedRecords.length > 0) {
-        indexed = await this.vectorRouter.upsertTools(normalizedRecords);
-        if (indexed) {
+        try {
+          ingestionResult = await this.vectorRouter.ingestTools(normalizedRecords, { force: true });
+        } catch (error) {
+          console.error('Vector ingestion failed:', error.message);
+        }
+
+        if (ingestionResult?.ingested > 0) {
           this.registryIndexHash = dataHash;
         }
       }


### PR DESCRIPTION
## Summary
- align the registry ingestion availability check with the router `isAvailable` API
- replace the upsert call with `ingestTools` and safely handle its result when updating the index hash
- add defensive logging around ingestion failures to avoid crashes when the router falls back to memory mode

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1ea6789c883269a163c2b4e40736b