### PR TITLE
Use normalizeRegistryEntries when ingesting registry data

### DIFF
--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -179,8 +179,8 @@ class WTFMCPManagerServer {
       const parsedRegistry = this.parseMCPRegistry(text);
       this.availableMCPs = parsedRegistry;
 
-      const normalizedRecords = this.normalizeRegistryRecords(Object.values(parsedRegistry));
-      this.registryToolRecords = normalizedRecords;
+      const normalizedEntries = this.normalizeRegistryEntries(Object.values(parsedRegistry));
+      this.registryToolRecords = normalizedEntries;
 
       await this.updateVectorIndexFromRegistry(parsedRegistry, { force: true });
 
@@ -192,8 +192,8 @@ class WTFMCPManagerServer {
       const shouldIndex = force || this.registryIndexHash !== dataHash || this.vectorRouter.available === false;
       let indexed = false;
 
-      if (shouldIndex && normalizedRecords.length > 0) {
-        indexed = await this.vectorRouter.upsertTools(normalizedRecords);
+      if (shouldIndex && normalizedEntries.length > 0) {
+        indexed = await this.vectorRouter.upsertTools(normalizedEntries);
         if (indexed) {
           this.registryIndexHash = dataHash;
         }


### PR DESCRIPTION
## Summary
- update fetchAvailableMCPs to normalize registry data using normalizeRegistryEntries before vector ingestion

## Testing
- npm test *(fails: test/retriever.test.js expects MCPVectorRetriever export)*

------
https://chatgpt.com/codex/tasks/task_e_68e1ea70c6e883269f96dd59cbaccb52