### PR TITLE
Switch MCP registry indexing to ingestTools

### DIFF
--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -193,8 +193,10 @@ class WTFMCPManagerServer {
       let indexed = false;
 
       if (shouldIndex && normalizedRecords.length > 0) {
-        indexed = await this.vectorRouter.upsertTools(normalizedRecords);
-        if (indexed) {
+        const result = await this.vectorRouter.ingestTools(normalizedRecords);
+        indexed = result?.skipped ? false : (result?.ingested || 0) > 0;
+
+        if (result && (result.skipped || indexed)) {
           this.registryIndexHash = dataHash;
         }
       }


### PR DESCRIPTION
## Summary
- update the MCP registry fetcher to call `ingestTools` so the vector router uses the new ingestion API
- record the registry index hash when ingestion succeeds or is skipped according to the new response shape

## Testing
- node test/vector-router.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e1ea72d13c8326a1fc413faa7e2b0d