### PR TITLE
Add vector router upsert alias

### DIFF
--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -58,6 +58,22 @@ class WTFMCPManagerServer {
     }
   }
 
+  getVectorRouterUpsertFunction() {
+    if (!this.vectorRouter) {
+      return null;
+    }
+
+    if (typeof this.vectorRouter.upsertTools === 'function') {
+      return this.vectorRouter.upsertTools.bind(this.vectorRouter);
+    }
+
+    if (typeof this.vectorRouter.ingestTools === 'function') {
+      return this.vectorRouter.ingestTools.bind(this.vectorRouter);
+    }
+
+    return null;
+  }
+
   /**
    * Analyze global and project-level MCP configurations
    */
@@ -192,8 +208,9 @@ class WTFMCPManagerServer {
       const shouldIndex = force || this.registryIndexHash !== dataHash || this.vectorRouter.available === false;
       let indexed = false;
 
-      if (shouldIndex && normalizedRecords.length > 0) {
-        indexed = await this.vectorRouter.upsertTools(normalizedRecords);
+      const upsertFn = this.getVectorRouterUpsertFunction();
+      if (shouldIndex && normalizedRecords.length > 0 && upsertFn) {
+        indexed = await upsertFn(normalizedRecords);
         if (indexed) {
           this.registryIndexHash = dataHash;
         }
@@ -386,7 +403,8 @@ class WTFMCPManagerServer {
   }
 
   async updateVectorIndexFromRegistry(entries, options = {}) {
-    if (!this.vectorRouter?.ingestTools) {
+    const upsertFn = this.getVectorRouterUpsertFunction();
+    if (!upsertFn) {
       return;
     }
 
@@ -396,7 +414,7 @@ class WTFMCPManagerServer {
     }
 
     try {
-      await this.vectorRouter.ingestTools(normalized, options);
+      await upsertFn(normalized, options);
     } catch (error) {
       console.error('Failed to update vector index:', error.message);
     }

--- a/lib/router/vector-router.js
+++ b/lib/router/vector-router.js
@@ -234,6 +234,10 @@ export class VectorRouter {
     return { ingested: normalizedTools.length, mode: this.mode };
   }
 
+  async upsertTools(tools = [], options = {}) {
+    return this.ingestTools(tools, options);
+  }
+
   async query(query, limit = 5) {
     await this.ensureReady();
 


### PR DESCRIPTION
## Summary
- add a VectorRouter.upsertTools alias so callers expecting an upsert method can reuse the existing ingestion implementation
- centralize VectorRouter ingestion method lookup in the MCP server and use it for registry indexing paths

## Testing
- npm test *(fails: SyntaxError importing MCPVectorRetriever due to missing export in retriever.js)*
- node --test test/vector-router.test.js


------
https://chatgpt.com/codex/tasks/task_e_68e1ea59ecec8326baf273ce612bf271