### PR TITLE
Use limit for vector search payloads

### DIFF
--- a/lib/server/retriever.js
+++ b/lib/server/retriever.js
@@ -87,7 +87,7 @@ export class RouterRetriever {
         url = `${endpointBase}/search`;
         body = {
           vector: embedding,
-          top: limit,
+          limit,
           with_payload: true,
           filter
         };

--- a/test/router-retriever.test.js
+++ b/test/router-retriever.test.js
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import RouterRetriever from '../lib/server/retriever.js';
+
+test('RouterRetriever uses limit in vector search payloads', async () => {
+  const retriever = new RouterRetriever({
+    vectorUrl: 'http://vector.example',
+    collection: 'test-collection'
+  });
+
+  retriever.getEmbedding = async () => [0.1, 0.2, 0.3];
+
+  const originalFetch = globalThis.fetch;
+  let fetchCall;
+
+  globalThis.fetch = async (url, options) => {
+    fetchCall = { url, options };
+    return {
+      ok: true,
+      json: async () => ({ result: [] })
+    };
+  };
+
+  try {
+    await retriever.queryVectorDB('test query', { limit: 7 });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.ok(fetchCall, 'fetch should be called for vector searches');
+  assert.ok(fetchCall.url.endsWith('/points/search'), 'vector search endpoint should be used');
+
+  const payload = JSON.parse(fetchCall.options.body);
+  assert.strictEqual(payload.limit, 7, 'search payload should include limit');
+  assert.ok(!Object.prototype.hasOwnProperty.call(payload, 'top'), 'search payload should not include top');
+});


### PR DESCRIPTION
## Summary
- update the router retriever to send `limit` in `/points/search` requests
- add a regression test that verifies the request payload uses `limit` and omits `top`

## Testing
- npm test *(fails: test/retriever.test.js expects MCPVectorRetriever export from lib/router/retriever.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e1ea695354832689b623dd85fe2f50