### PR TITLE
Use VectorRouter ingestion result when indexing registry

### DIFF
--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -192,8 +192,10 @@ class WTFMCPManagerServer {
       const shouldIndex = force || this.registryIndexHash !== dataHash || this.vectorRouter.available === false;
       let indexed = false;
 
-      if (shouldIndex && normalizedRecords.length > 0) {
-        indexed = await this.vectorRouter.upsertTools(normalizedRecords);
+      if (shouldIndex && normalizedRecords.length > 0 && typeof this.vectorRouter?.ingestTools === 'function') {
+        const ingestionResult = await this.vectorRouter.ingestTools(normalizedRecords, { force: true });
+        indexed = (ingestionResult?.ingested || 0) > 0;
+
         if (indexed) {
           this.registryIndexHash = dataHash;
         }


### PR DESCRIPTION
## Summary
- update `fetchAvailableMCPs` to ingest registry tools through `VectorRouter.ingestTools`
- only refresh the registry hash when ingestion reports stored records

## Testing
- node test/test-mcp-server.js
- node test/vector-router.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e1ea78b60483269bb7e7f17de772b8