### PR TITLE
Fix CLI ingest missing VectorStoreIngestor import

### DIFF
--- a/bin/wtf-mcp.js
+++ b/bin/wtf-mcp.js
@@ -18,6 +18,7 @@ import { MCPManager } from '../lib/manager.js';
 import { MCPRegistry } from '../lib/registry.js';
 import { AutoDetector } from '../lib/detector.js';
 import { RouterClient } from '../lib/router/client.js';
+import { VectorStoreIngestor } from '../lib/router/vector-store.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);


### PR DESCRIPTION
## Summary
- add the missing VectorStoreIngestor import to the CLI entry point so the ingest command can instantiate it

## Testing
- CI=1 node bin/wtf-mcp.js ingest --provider memory --embedding-provider mock

------
https://chatgpt.com/codex/tasks/task_e_68e1ebdd5298832686a7f21da0085cc3