### PR TITLE
Fix template resolution for dynamic MCP generator

### DIFF
--- a/lib/dynamic/mcp-generator.js
+++ b/lib/dynamic/mcp-generator.js
@@ -5,6 +5,7 @@
 
 import fs from 'fs/promises';
 import path from 'path';
+import { fileURLToPath } from 'node:url';
 import { spawn } from 'child_process';
 import crypto from 'crypto';
 
@@ -14,6 +15,7 @@ export class DynamicMCPGenerator {
     this.activeMCPs = new Map();
     this.templates = new Map();
     this.portCounter = 9000;
+    this.templatesDir = fileURLToPath(new URL('../templates', import.meta.url));
   }
 
   async init() {
@@ -24,8 +26,6 @@ export class DynamicMCPGenerator {
 
   async loadTemplates() {
     // Load MCP generation templates
-    const templatesDir = path.join(process.cwd(), 'lib', 'templates');
-
     this.templates.set('rest-api', {
       type: 'rest',
       language: 'javascript',
@@ -53,11 +53,15 @@ export class DynamicMCPGenerator {
 
   async loadTemplate(filename) {
     try {
-      const templatePath = path.join(process.cwd(), 'lib', 'templates', filename);
+      const templatePath = path.join(this.templatesDir, filename);
       return await fs.readFile(templatePath, 'utf-8');
     } catch (error) {
-      // Return a basic template if file doesn't exist yet
-      return this.getDefaultTemplate(filename);
+      if (error && error.code === 'ENOENT') {
+        // Return a basic template if file doesn't exist yet
+        return this.getDefaultTemplate(filename);
+      }
+
+      throw error;
     }
   }
 

--- a/test/test-dynamic-generation.js
+++ b/test/test-dynamic-generation.js
@@ -9,6 +9,9 @@ import { APIDiscoveryService } from '../lib/discovery/api-discovery.js';
 import chalk from 'chalk';
 import http from 'node:http';
 import assert from 'node:assert';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 
 async function testDynamicGeneration() {
   console.log(chalk.cyan('\n🧪 Testing Dynamic MCP Generation System\n'));
@@ -107,6 +110,24 @@ async function testDynamicGeneration() {
     }
   } catch (error) {
     console.log(chalk.red('❌ Template system failed:'), error.message);
+  }
+
+  // Test 5b: Template loading from alternate working directory
+  console.log(chalk.yellow('\n5b. Testing template loading from alternate working directory...'));
+  const originalCwd = process.cwd();
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcp-generator-test-'));
+  try {
+    process.chdir(tempDir);
+    const altGenerator = new DynamicMCPGenerator();
+    await altGenerator.init();
+    const restTemplate = altGenerator.templates.get('rest-api')?.template ?? '';
+    assert.ok(restTemplate.includes('Type: REST API'), 'Expected real REST template to load');
+    console.log(chalk.green('✅ Templates loaded correctly from module-relative directory'));
+  } catch (error) {
+    console.log(chalk.red('❌ Template loading from alternate directory failed:'), error.message);
+  } finally {
+    process.chdir(originalCwd);
+    await fs.rm(tempDir, { recursive: true, force: true });
   }
 
   // Test 6: API specification detection


### PR DESCRIPTION
## Summary
- resolve dynamic MCP template paths relative to the generator module instead of process cwd
- only fall back to default inline templates when the template file is actually missing
- add a regression test to confirm templates still load when invoked from another working directory

## Testing
- node test/test-dynamic-generation.js

------
https://chatgpt.com/codex/tasks/task_e_68e1ebedbd8c83269cfe0b77db0cbe38