### PR TITLE
Load .claude environment before CLI commands

### DIFF
--- a/bin/wtf-mcp.js
+++ b/bin/wtf-mcp.js
@@ -23,6 +23,26 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const packageJson = JSON.parse(await fs.readFile(join(__dirname, '..', 'package.json'), 'utf8'));
 
+function loadClaudeEnv(envPath = join(process.cwd(), '.claude', '.env')) {
+  if (process.env.__WTF_MCP_ENV_LOADED) {
+    return;
+  }
+
+  try {
+    if (existsSync(envPath)) {
+      dotenv.config({ path: envPath, override: false });
+    } else {
+      dotenv.config();
+    }
+  } catch (error) {
+    console.warn(chalk.yellow(`[wtf-mcp-manager] Unable to load environment file: ${error.message}`));
+  }
+
+  process.env.__WTF_MCP_ENV_LOADED = 'true';
+}
+
+loadClaudeEnv();
+
 const program = new Command();
 const manager = new MCPManager();
 const routerClient = new RouterClient();


### PR DESCRIPTION
## Summary
- load environment variables from .claude/.env before the CLI reads process.env
- guard the dotenv initialization so the file is only read once

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1ec302aa483269a4a3a18c13a7607