### PR TITLE
Ensure Playwright and Sequential Thinking run non-interactively

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -41,7 +41,7 @@ export class MCPRegistry {
         name: 'Playwright',
         package: '@playwright/mcp@latest',
         command: 'npx',
-        args: ['@playwright/mcp@latest'],
+        args: ['-y', '@playwright/mcp@latest'],
         requiredEnv: [],
         description: '🎭 Browser Automation - Control browsers',
         categories: ['automation', 'testing'],
@@ -71,7 +71,7 @@ export class MCPRegistry {
         name: 'Sequential Thinking',
         package: '@modelcontextprotocol/server-sequential-thinking',
         command: 'npx',
-        args: ['@modelcontextprotocol/server-sequential-thinking'],
+        args: ['-y', '@modelcontextprotocol/server-sequential-thinking'],
         requiredEnv: [],
         description: '🧠 AI Reasoning - Step-by-step thinking',
         categories: ['ai', 'reasoning']


### PR DESCRIPTION
## Summary
- add the `-y` flag to the Playwright and Sequential Thinking registry entries so npx runs non-interactively
- verified other npx-backed registry entries remain unchanged
- manually enabled Playwright through the manager to confirm the stored command includes the non-interactive flag

## Testing
- `node --input-type=module <<'NODE'
import { MCPManager } from './lib/manager.js';
const manager = new MCPManager(process.cwd());
await manager.enable('playwright');
console.log('enabled');
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68e1ec2e498c83269486ad73ffde2ae2