### PR TITLE
Add vector store ingestion helpers for CLI

### DIFF
--- a/bin/wtf-mcp.js
+++ b/bin/wtf-mcp.js
@@ -18,6 +18,7 @@ import { MCPManager } from '../lib/manager.js';
 import { MCPRegistry } from '../lib/registry.js';
 import { AutoDetector } from '../lib/detector.js';
 import { RouterClient } from '../lib/router/client.js';
+import VectorStoreIngestor, { collectMCPMetadata, ingestToVectorStore } from '../lib/router/vector-store.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/lib/router/vector-store.js
+++ b/lib/router/vector-store.js
@@ -829,4 +829,318 @@ export class VectorStoreFactory {
   }
 }
 
+export async function collectMCPMetadata(options = {}) {
+  const ingestor = new VectorStoreIngestor(options);
+  return ingestor.collectDocuments();
+}
+
+export function toVectorRecord(document = {}) {
+  if (!document || typeof document !== 'object') {
+    return {
+      id: undefined,
+      source: undefined,
+      name: undefined,
+      description: undefined,
+      schema: undefined,
+      example: undefined,
+      metadata: {},
+      document: '',
+      text: '',
+      embedding: undefined
+    };
+  }
+
+  const {
+    id,
+    source,
+    name,
+    description,
+    schema = null,
+    example = '',
+    metadata = {},
+    text = '',
+    embedding
+  } = document;
+
+  return {
+    id,
+    source,
+    name,
+    description,
+    schema,
+    example,
+    metadata,
+    document: text || '',
+    text: text || '',
+    embedding
+  };
+}
+
+function getVectorStoreConfig(options = {}) {
+  const config = options.vectorStoreConfig || {};
+  return {
+    provider: (config.provider || options.provider || process.env.VECTOR_DB_PROVIDER || 'memory').toLowerCase(),
+    url: config.url || options.vectorStoreUrl || options.url || process.env.VECTOR_DB_URL,
+    collection: config.collection || options.collection || process.env.VECTOR_DB_COLLECTION,
+    table: config.table || options.table || process.env.VECTOR_DB_TABLE,
+    apiKey: config.apiKey || options.vectorStoreApiKey || options.apiKey || process.env.VECTOR_DB_API_KEY
+  };
+}
+
+async function embedDocumentsWithProvider(documents, provider) {
+  if (!provider || typeof provider.embed !== 'function') {
+    throw new Error('Embedding provider must expose an embed() function');
+  }
+
+  const inputs = documents.map(doc => doc.text || '');
+
+  if (provider.embed.length >= 2) {
+    return Promise.all(documents.map(doc => provider.embed(doc.text || '', doc)));
+  }
+
+  const result = await provider.embed(inputs);
+  if (!Array.isArray(result)) {
+    throw new Error('Embedding provider embed() must return an array of embeddings');
+  }
+  if (result.length !== documents.length) {
+    throw new Error('Embedding provider returned a different number of embeddings than documents');
+  }
+  return result;
+}
+
+export async function ingestToVectorStore(options = {}) {
+  const config = getVectorStoreConfig(options);
+  const {
+    embeddingProvider,
+    vectorStore,
+    vectorStoreConfig, // eslint-disable-line no-unused-vars
+    ...ingestorOptions
+  } = options;
+
+  const ingestor = new VectorStoreIngestor({
+    ...ingestorOptions,
+    provider: config.provider,
+    vectorProvider: config.provider,
+    url: config.url,
+    collection: config.collection,
+    table: config.table,
+    apiKey: config.apiKey
+  });
+
+  const documents = await ingestor.collectDocuments();
+  if (documents.length === 0) {
+    return { count: 0, provider: config.provider, collection: config.collection, ids: [] };
+  }
+
+  let embeddedDocs;
+  if (embeddingProvider) {
+    const embeddings = await embedDocumentsWithProvider(documents, embeddingProvider);
+    embeddedDocs = documents.map((doc, index) => ({ ...doc, embedding: embeddings[index] }));
+  } else {
+    embeddedDocs = await ingestor.embedDocuments(documents);
+  }
+
+  const vectorRecords = embeddedDocs.map(doc => ({ ...toVectorRecord(doc), embedding: doc.embedding }));
+
+  let store = vectorStore || null;
+  if (!store) {
+    store = new VectorStoreClient(config);
+  }
+
+  if (typeof store.ensureCollection === 'function') {
+    await store.ensureCollection();
+  }
+
+  if (typeof store.upsert === 'function') {
+    await store.upsert(vectorRecords);
+  } else if (typeof store.upsertMany === 'function') {
+    await store.upsertMany(vectorRecords);
+  } else {
+    // Fallback to the ingestor's vector database implementation
+    await ingestor.vectorDb.upsertMany(embeddedDocs);
+  }
+
+  return {
+    count: vectorRecords.length,
+    provider: store.provider || config.provider,
+    collection: store.collection || config.collection || null,
+    ids: vectorRecords.map(record => record.id)
+  };
+}
+
+export class VectorStoreClient {
+  constructor(config = {}, fetchImpl = fetch) {
+    this.provider = (config.provider || process.env.VECTOR_DB_PROVIDER || 'memory').toLowerCase();
+    this.url = config.url || process.env.VECTOR_DB_URL || '';
+    this.collection = config.collection || process.env.VECTOR_DB_COLLECTION || 'mcp_metadata';
+    this.table = config.table || process.env.VECTOR_DB_TABLE || 'mcp_vectors';
+    this.apiKey = config.apiKey || process.env.VECTOR_DB_API_KEY;
+    this.fetch = fetchImpl;
+  }
+
+  async ensureCollection() {
+    switch (this.provider) {
+      case 'chroma':
+        return this.ensureChromaCollection();
+      case 'qdrant':
+        return this.ensureQdrantCollection();
+      case 'supabase':
+      case 'memory':
+      default:
+        return undefined;
+    }
+  }
+
+  async ensureChromaCollection() {
+    if (!this.url || !this.collection) return;
+    const endpoint = new URL('/api/v1/collections', this.url).toString();
+    const response = await this.fetch(endpoint, {
+      method: 'POST',
+      headers: this.buildHeaders({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify({ name: this.collection })
+    });
+
+    if (!response.ok && response.status !== 409) {
+      const body = await response.text();
+      throw new Error(`Failed to ensure Chroma collection: ${response.status} ${body}`);
+    }
+  }
+
+  async ensureQdrantCollection() {
+    if (!this.url || !this.collection) return;
+    const endpoint = new URL(`/collections/${this.collection}`, this.url).toString();
+    const response = await this.fetch(endpoint, {
+      method: 'PUT',
+      headers: this.buildHeaders({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify({
+        vectors: {
+          size: 1536,
+          distance: 'Cosine'
+        }
+      })
+    });
+
+    if (!response.ok && response.status !== 409) {
+      const body = await response.text();
+      throw new Error(`Failed to ensure Qdrant collection: ${response.status} ${body}`);
+    }
+  }
+
+  async upsert(records = []) {
+    switch (this.provider) {
+      case 'chroma':
+        return this.upsertChroma(records);
+      case 'qdrant':
+        return this.upsertQdrant(records);
+      case 'supabase':
+        return this.upsertSupabase(records);
+      case 'memory':
+      default:
+        this.records = this.records || [];
+        this.records.push(...records);
+        return;
+    }
+  }
+
+  buildHeaders(base = {}) {
+    const headers = { ...base };
+    if (this.apiKey) {
+      if (this.provider === 'chroma') {
+        headers['Authorization'] = `Bearer ${this.apiKey}`;
+      } else {
+        headers['api-key'] = this.apiKey;
+      }
+    }
+    return headers;
+  }
+
+  async upsertChroma(records) {
+    if (!this.url || !this.collection || records.length === 0) return;
+    const endpoint = new URL(`/api/v1/collections/${this.collection}/upsert`, this.url).toString();
+    const body = {
+      ids: records.map(record => record.id),
+      embeddings: records.map(record => record.embedding),
+      documents: records.map(record => record.document || record.text || ''),
+      metadatas: records.map(record => ({
+        source: record.source,
+        name: record.name,
+        description: record.description,
+        example: record.example,
+        ...record.metadata
+      }))
+    };
+
+    const response = await this.fetch(endpoint, {
+      method: 'POST',
+      headers: this.buildHeaders({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify(body)
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(`Failed to upsert records into Chroma: ${response.status} ${errorBody}`);
+    }
+  }
+
+  async upsertQdrant(records) {
+    if (!this.url || !this.collection || records.length === 0) return;
+    const endpoint = new URL(`/collections/${this.collection}/points?wait=true`, this.url).toString();
+    const body = {
+      points: records.map(record => ({
+        id: record.id,
+        vector: record.embedding,
+        payload: {
+          source: record.source,
+          name: record.name,
+          description: record.description,
+          schema: record.schema,
+          example: record.example,
+          ...record.metadata
+        }
+      }))
+    };
+
+    const response = await this.fetch(endpoint, {
+      method: 'PUT',
+      headers: this.buildHeaders({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify(body)
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(`Failed to upsert records into Qdrant: ${response.status} ${errorBody}`);
+    }
+  }
+
+  async upsertSupabase(records) {
+    if (!this.url || records.length === 0) return;
+    const endpoint = `${this.url.replace(/\/$/, '')}/${this.table}`;
+    const body = records.map(record => ({
+      id: record.id,
+      source: record.source,
+      name: record.name,
+      description: record.description,
+      schema: record.schema ? JSON.stringify(record.schema) : null,
+      example: record.example,
+      text: record.document || record.text || '',
+      embedding: record.embedding,
+      metadata: record.metadata || {}
+    }));
+
+    const response = await this.fetch(endpoint, {
+      method: 'POST',
+      headers: this.buildHeaders({
+        'Content-Type': 'application/json',
+        'Prefer': 'resolution=merge-duplicates'
+      }),
+      body: JSON.stringify(body)
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(`Failed to upsert records into Supabase: ${response.status} ${errorBody}`);
+    }
+  }
+}
+
 export default VectorStoreIngestor;


### PR DESCRIPTION
## Summary
- add helper exports to the vector store module for metadata collection and ingestion
- implement a vector store HTTP client with collection management and provider-specific upserts
- update the CLI to import the new ingestion helpers

## Testing
- node test/test-ingestion.js

------
https://chatgpt.com/codex/tasks/task_e_68e1ec2d321483268bf57d235289b8d2