### PR TITLE
Load CLI env vars from .claude/.env and add regression test

### DIFF
--- a/bin/wtf-mcp.js
+++ b/bin/wtf-mcp.js
@@ -23,6 +23,23 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const packageJson = JSON.parse(await fs.readFile(join(__dirname, '..', 'package.json'), 'utf8'));
 
+// Load project environment variables from .claude/.env (fallback to .env)
+const envPaths = [
+  join(process.cwd(), '.claude', '.env'),
+  join(process.cwd(), '.env')
+];
+
+for (const envPath of envPaths) {
+  if (existsSync(envPath)) {
+    try {
+      dotenv.config({ path: envPath, override: false });
+    } catch (error) {
+      console.warn(chalk.yellow(`⚠️  Failed to load env file at ${envPath}: ${error.message || error}`));
+    }
+    break;
+  }
+}
+
 const program = new Command();
 const manager = new MCPManager();
 const routerClient = new RouterClient();

--- a/test/manager.test.js
+++ b/test/manager.test.js
@@ -48,3 +48,49 @@ test('init and enable handle custom backend profile', async t => {
     'enabled MCP should be recorded in the configuration'
   );
 });
+
+test('CLI loads .claude env variables before prompting', async t => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcp-manager-cli-'));
+
+  t.after(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const envDir = path.join(tempDir, '.claude');
+  await fs.mkdir(envDir, { recursive: true });
+
+  const envKey = 'WTF_MCP_FAKE_TOKEN';
+  const envValue = 'super-secret';
+  await fs.writeFile(path.join(envDir, '.env'), `${envKey}=${envValue}\n`, 'utf8');
+
+  const originalCwd = process.cwd();
+  const originalArgv = [...process.argv];
+  const previousEnvValue = process.env[envKey];
+  const originalExit = process.exit;
+  const originalExitCode = process.exitCode;
+
+  delete process.env[envKey];
+  process.chdir(tempDir);
+  process.argv = ['node', 'wtf-mcp-manager'];
+  process.exit = () => {};
+
+  try {
+    await import('../bin/wtf-mcp.js');
+    assert.strictEqual(
+      process.env[envKey],
+      envValue,
+      'env variables from .claude/.env should populate process.env before CLI prompts'
+    );
+  } finally {
+    process.exit = originalExit;
+    process.exitCode = originalExitCode;
+    process.argv = originalArgv;
+    process.chdir(originalCwd);
+
+    if (previousEnvValue === undefined) {
+      delete process.env[envKey];
+    } else {
+      process.env[envKey] = previousEnvValue;
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- load CLI environment variables from `.claude/.env` with a fallback to `.env`, only warning when a present file fails to parse
- add a regression test that ensures the CLI picks up `.claude/.env` secrets without prompting

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1ebe8008c83269bd45d457cda7c31