### PR TITLE
Refine ingest CLI with reusable vector store helpers

### DIFF
--- a/bin/wtf-mcp.js
+++ b/bin/wtf-mcp.js
@@ -18,6 +18,7 @@ import { MCPManager } from '../lib/manager.js';
 import { MCPRegistry } from '../lib/registry.js';
 import { AutoDetector } from '../lib/detector.js';
 import { RouterClient } from '../lib/router/client.js';
+import { VectorStoreIngestor } from '../lib/router/vector-store.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -397,9 +398,11 @@ program
   .option('--embedding-model <model>', 'Embedding model identifier override')
   .option('--embedding-endpoint <url>', 'Embedding HTTP endpoint override')
   .option('--env <path>', 'Path to .env file with credentials', join(process.cwd(), '.claude', '.env'))
+  .option('--dry-run', 'Collect metadata and preview without writing to the vector store', false)
   .action(async (options) => {
     showBanner();
-    const spinner = ora('Ingesting MCP metadata into vector store...').start();
+    const spinner = ora('Collecting MCP metadata...').start();
+    let ingestSpinner;
 
     try {
       const ingestor = new VectorStoreIngestor({
@@ -414,15 +417,42 @@ program
         envPath: options.env
       });
 
-      const result = await ingestor.ingestAll();
-      spinner.succeed(chalk.green(`✅ Ingested ${result.count} documents into ${result.provider} vector store`));
+      const documents = await ingestor.collectDocuments();
+      spinner.succeed(chalk.green(`Collected ${documents.length} MCP metadata records.`));
+
+      if (options.dryRun) {
+        if (documents.length === 0) {
+          console.log(chalk.yellow('No MCP metadata records available.'));
+        } else {
+          console.log(chalk.cyan('\n🧪 Dry run preview (first 3 records):\n'));
+          documents.slice(0, 3).forEach(record => {
+            console.log(chalk.yellow(`• ${record.name || record.id}`));
+            console.log(chalk.gray(`  Source: ${record.source}`));
+            if (record.description) {
+              console.log(chalk.gray(`  Description: ${record.description}`));
+            }
+            console.log('');
+          });
+        }
+        return;
+      }
+
+      ingestSpinner = ora('Writing embeddings to the vector store...').start();
+      const result = await ingestor.ingestDocuments(documents);
+      const location = [result.provider, result.collection].filter(Boolean).join(' / ');
+      const suffix = location ? ` into ${location}` : '';
+      ingestSpinner.succeed(chalk.green(`✅ Ingested ${result.count} documents${suffix}`));
 
       if (result.ids?.length) {
         const sampleIds = result.ids.slice(0, 5).join(', ');
         console.log(chalk.gray(`Sample document IDs: ${sampleIds}${result.ids.length > 5 ? ', ...' : ''}`));
       }
     } catch (error) {
-      spinner.fail(chalk.red(`Failed to ingest MCP metadata: ${error.message}`));
+      if (ingestSpinner) {
+        ingestSpinner.fail(chalk.red(`Failed to write to vector store: ${error.message}`));
+      } else {
+        spinner.fail(chalk.red(`Failed to ingest metadata: ${error.message}`));
+      }
       process.exit(1);
     }
   });
@@ -515,45 +545,6 @@ program
           console.log(chalk.gray(`    Fix: ${issue.fix}`));
         }
       });
-    }
-  });
-
-program
-  .command('ingest')
-  .description('Aggregate MCP metadata and push it into the configured vector store')
-  .option('--dry-run', 'Collect metadata and show a preview without writing to the vector store', false)
-  .action(async (options) => {
-    showBanner();
-    const spinner = ora('Collecting MCP metadata...').start();
-    let ingestSpinner;
-
-    try {
-      const records = await collectMCPMetadata();
-      spinner.succeed(chalk.green(`Collected ${records.length} MCP metadata records.`));
-
-      if (options.dryRun) {
-        console.log(chalk.cyan('\n🧪 Dry run preview (first 3 records):\n'));
-        records.slice(0, 3).forEach(record => {
-          console.log(chalk.yellow(`• ${record.name}`));
-          console.log(chalk.gray(`  Source: ${record.source}`));
-          if (record.description) {
-            console.log(chalk.gray(`  Description: ${record.description}`));
-          }
-          console.log('');
-        });
-        return;
-      }
-
-      ingestSpinner = ora('Writing embeddings to the vector store...').start();
-      const result = await ingestToVectorStore();
-      ingestSpinner.succeed(chalk.green(`Ingested ${result.count} records into ${result.provider} (${result.collection}).`));
-    } catch (error) {
-      if (ingestSpinner) {
-        ingestSpinner.fail(chalk.red(`Failed to write to vector store: ${error.message}`));
-      } else {
-        spinner.fail(chalk.red(`Failed to ingest metadata: ${error.message}`));
-      }
-      process.exit(1);
     }
   });
 

--- a/lib/router/vector-store.js
+++ b/lib/router/vector-store.js
@@ -148,8 +148,13 @@ class EmbeddingProviderFactory {
 }
 
 class AbstractVectorDatabase {
-  constructor(provider) {
+  constructor(provider, options = {}) {
     this.provider = provider;
+    this.collection = options.collection || null;
+  }
+
+  async ensureCollection() {
+    // Optional – override in subclasses if the provider requires it.
   }
 
   async upsertMany(records) {
@@ -158,8 +163,8 @@ class AbstractVectorDatabase {
 }
 
 export class MemoryVectorDatabase extends AbstractVectorDatabase {
-  constructor() {
-    super('memory');
+  constructor(options = {}) {
+    super('memory', options);
     this.records = [];
   }
 
@@ -170,7 +175,7 @@ export class MemoryVectorDatabase extends AbstractVectorDatabase {
 
 class ChromaVectorDatabase extends AbstractVectorDatabase {
   constructor(options = {}) {
-    super('chroma');
+    super('chroma', options);
     this.url = options.url || process.env.VECTOR_DB_URL || 'http://localhost:8000';
     this.collection = options.collection || process.env.VECTOR_DB_COLLECTION || 'mcp_metadata';
     this.apiKey = options.apiKey || process.env.VECTOR_DB_API_KEY;
@@ -214,7 +219,7 @@ class ChromaVectorDatabase extends AbstractVectorDatabase {
 
 class QdrantVectorDatabase extends AbstractVectorDatabase {
   constructor(options = {}) {
-    super('qdrant');
+    super('qdrant', options);
     this.url = options.url || process.env.VECTOR_DB_URL || 'http://localhost:6333';
     this.collection = options.collection || process.env.VECTOR_DB_COLLECTION || 'mcp_metadata';
     this.apiKey = options.apiKey || process.env.VECTOR_DB_API_KEY;
@@ -260,7 +265,7 @@ class QdrantVectorDatabase extends AbstractVectorDatabase {
 
 class SupabaseVectorDatabase extends AbstractVectorDatabase {
   constructor(options = {}) {
-    super('supabase');
+    super('supabase', { collection: options.table || process.env.VECTOR_DB_TABLE || 'mcp_vectors' });
     this.url = options.url || process.env.VECTOR_DB_URL;
     this.table = options.table || process.env.VECTOR_DB_TABLE || 'mcp_vectors';
     this.apiKey = options.apiKey || process.env.VECTOR_DB_API_KEY;
@@ -302,6 +307,69 @@ class SupabaseVectorDatabase extends AbstractVectorDatabase {
     if (!response.ok) {
       const errorBody = await response.text();
       throw new Error(`Failed to upsert embeddings into Supabase: ${response.status} ${errorBody}`);
+    }
+  }
+}
+
+export class VectorStoreClient extends AbstractVectorDatabase {
+  constructor(config = {}, fetchImpl = fetch) {
+    super(config.provider || 'chroma', { collection: config.collection });
+    this.url = config.url || process.env.VECTOR_DB_URL || 'http://localhost:8000';
+    this.collection = config.collection || process.env.VECTOR_DB_COLLECTION || 'mcp_metadata';
+    this.apiKey = config.apiKey || process.env.VECTOR_DB_API_KEY;
+    this.fetch = fetchImpl;
+  }
+
+  async ensureCollection() {
+    const endpoint = new URL('/api/v1/collections', this.url).toString();
+    const headers = { 'Content-Type': 'application/json' };
+
+    if (this.apiKey) {
+      headers['Authorization'] = `Bearer ${this.apiKey}`;
+    }
+
+    const response = await this.fetch(endpoint, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ name: this.collection })
+    });
+
+    if (!response.ok && response.status !== 409) {
+      const errorBody = await response.text();
+      throw new Error(`Failed to ensure vector collection: ${response.status} ${errorBody}`);
+    }
+  }
+
+  async upsertMany(records) {
+    const endpoint = new URL(`/api/v1/collections/${this.collection}/upsert`, this.url).toString();
+    const headers = { 'Content-Type': 'application/json' };
+
+    if (this.apiKey) {
+      headers['Authorization'] = `Bearer ${this.apiKey}`;
+    }
+
+    const body = {
+      ids: records.map(record => record.id),
+      embeddings: records.map(record => record.embedding),
+      metadatas: records.map(record => ({
+        source: record.source,
+        name: record.name,
+        description: record.description,
+        example: record.example,
+        ...record.metadata
+      })),
+      documents: records.map(record => record.text)
+    };
+
+    const response = await this.fetch(endpoint, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body)
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(`Failed to upsert embeddings: ${response.status} ${errorBody}`);
     }
   }
 }
@@ -350,6 +418,8 @@ export class VectorStoreIngestor {
     };
 
     this.vectorDb = options.vectorDb || VectorDatabaseFactory.create(vectorOptions);
+    this.collection = vectorOptions.collection || this.vectorDb.collection || null;
+    this._collectionEnsured = false;
     this.embeddingClient = options.embeddingClient || null;
     this.embeddingClientPromise = (async () => {
       if (this.embeddingClient) {
@@ -504,21 +574,133 @@ export class VectorStoreIngestor {
     }));
   }
 
-  async ingestAll() {
-    const documents = await this.collectDocuments();
-    if (documents.length === 0) {
-      return { count: 0, provider: this.vectorDb.provider };
+  async ensureVectorCollection() {
+    if (this._collectionEnsured) {
+      return;
     }
 
-    const embedded = await this.embedDocuments(documents);
-    await this.vectorDb.upsertMany(embedded);
+    if (typeof this.vectorDb.ensureCollection === 'function') {
+      await this.vectorDb.ensureCollection();
+    }
 
+    this._collectionEnsured = true;
+  }
+
+  async ingestDocuments(documents = []) {
+    if (!documents.length) {
+      return {
+        count: 0,
+        provider: this.vectorDb.provider,
+        collection: this.collection,
+        ids: []
+      };
+    }
+
+    await this.ensureVectorCollection();
+    const embedded = await this.embedDocuments(documents);
+
+    if (typeof this.vectorDb.upsertMany === 'function') {
+      await this.vectorDb.upsertMany(embedded);
+    } else if (typeof this.vectorDb.upsert === 'function') {
+      await this.vectorDb.upsert(embedded);
+    } else {
+      throw new Error('Vector database does not implement an upsert method');
+    }
+
+    const ids = embedded.map(doc => doc.id);
     return {
       count: embedded.length,
       provider: this.vectorDb.provider,
-      ids: embedded.map(doc => doc.id)
+      collection: this.collection,
+      ids
     };
   }
+
+  async ingestAll() {
+    const documents = await this.collectDocuments();
+    return this.ingestDocuments(documents);
+  }
+}
+
+export function toVectorRecord(document) {
+  return {
+    id: document.id,
+    source: document.source,
+    name: document.name,
+    description: document.description,
+    schema: document.schema,
+    example: document.example,
+    metadata: document.metadata || {},
+    document: document.text,
+    embedding: document.embedding
+  };
+}
+
+export async function collectMCPMetadata(options = {}) {
+  const ingestor = new VectorStoreIngestor(options);
+  return ingestor.collectDocuments();
+}
+
+export async function ingestToVectorStore(options = {}) {
+  const {
+    dryRun = false,
+    vectorStore,
+    vectorStoreConfig = {},
+    embeddingProvider,
+    envPath
+  } = options;
+
+  const ingestorOptions = {
+    ...vectorStoreConfig,
+    provider: vectorStoreConfig.provider,
+    vectorProvider: vectorStoreConfig.provider,
+    url: vectorStoreConfig.url,
+    collection: vectorStoreConfig.collection,
+    table: vectorStoreConfig.table,
+    embeddingClient: undefined,
+    envPath
+  };
+
+  if (vectorStore) {
+    const wrapped = {
+      provider: vectorStore.provider || vectorStoreConfig.provider || 'custom',
+      collection: vectorStore.collection || vectorStoreConfig.collection || null
+    };
+
+    if (typeof vectorStore.ensureCollection === 'function') {
+      wrapped.ensureCollection = vectorStore.ensureCollection.bind(vectorStore);
+    }
+
+    if (typeof vectorStore.upsertMany === 'function') {
+      wrapped.upsertMany = vectorStore.upsertMany.bind(vectorStore);
+    } else if (typeof vectorStore.upsert === 'function') {
+      wrapped.upsertMany = async (records) => vectorStore.upsert(records);
+    } else {
+      throw new Error('Provided vectorStore must implement upsertMany or upsert');
+    }
+
+    ingestorOptions.vectorDb = wrapped;
+  }
+
+  if (embeddingProvider) {
+    if (typeof embeddingProvider.embed !== 'function') {
+      throw new Error('Embedding provider must implement an embed(texts) method');
+    }
+    ingestorOptions.embeddingClient = embeddingProvider;
+  }
+
+  const ingestor = new VectorStoreIngestor(ingestorOptions);
+
+  if (dryRun) {
+    const documents = await ingestor.collectDocuments();
+    return {
+      dryRun: true,
+      count: documents.length,
+      records: documents.map(toVectorRecord)
+    };
+  }
+
+  return ingestor.ingestAll();
 }
 
 export default VectorStoreIngestor;

--- a/test/vector-store.test.js
+++ b/test/vector-store.test.js
@@ -1,12 +1,31 @@
 #!/usr/bin/env node
 
-import assert from 'assert/strict';
-import chalk from 'chalk';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { promisify } from 'node:util';
+import { execFile } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
 import { VectorStoreIngestor, MemoryVectorDatabase, MockEmbeddingClient } from '../lib/router/vector-store.js';
 
-async function runVectorStoreTests() {
-  console.log(chalk.cyan('\n🧪 Testing vector store ingestion\n'));
+const execFileAsync = promisify(execFile);
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
+const SAMPLE_DOCS = [
+  {
+    id: 'test:doc',
+    source: 'test',
+    name: 'Test Document',
+    description: 'Ensures async embedding initialization resolves correctly',
+    schema: null,
+    example: '',
+    text: 'Sample text for embedding',
+    metadata: {}
+  }
+];
+
+test('VectorStoreIngestor embeds and ingests documents with an explicit embedding client', async () => {
   const vectorDb = new MemoryVectorDatabase();
   const embeddingClient = new MockEmbeddingClient();
 
@@ -17,47 +36,38 @@ async function runVectorStoreTests() {
     embeddingProvider: 'mock'
   });
 
-  const sampleDocs = [
-    {
-      id: 'test:doc',
-      source: 'test',
-      name: 'Test Document',
-      description: 'Ensures async embedding initialization resolves correctly',
-      schema: null,
-      example: '',
-      text: 'Sample text for embedding',
-      metadata: {}
-    }
-  ];
+  const embeddedDocs = await ingestor.embedDocuments(SAMPLE_DOCS);
+  assert.equal(embeddedDocs.length, SAMPLE_DOCS.length);
+  assert.ok(Array.isArray(embeddedDocs[0].embedding));
+  assert.ok(ingestor.embeddingClient, 'embedding client should be resolved');
 
-  const embeddedDocs = await ingestor.embedDocuments(sampleDocs);
-  assert.equal(embeddedDocs.length, sampleDocs.length, 'embedDocuments should return embeddings for all docs');
-  assert.ok(Array.isArray(embeddedDocs[0].embedding), 'embedded document should include an embedding array');
-  assert.ok(ingestor.embeddingClient, 'embedding client should be resolved after embedding');
+  const result = await ingestor.ingestDocuments(SAMPLE_DOCS);
+  assert.equal(result.count, SAMPLE_DOCS.length);
+  assert.equal(result.provider, 'memory');
+  assert.equal(vectorDb.records.length, SAMPLE_DOCS.length);
+});
 
+test('VectorStoreIngestor resolves an embedding client asynchronously', async () => {
   const asyncIngestor = new VectorStoreIngestor({
     vectorDb: new MemoryVectorDatabase(),
     provider: 'memory',
     embeddingProvider: 'mock'
   });
-  const asyncEmbeddedDocs = await asyncIngestor.embedDocuments(sampleDocs);
-  assert.ok(Array.isArray(asyncEmbeddedDocs[0].embedding), 'async-created embedding client should embed documents');
-  assert.ok(asyncIngestor.embeddingClient, 'async-created embedding client should resolve during embedding');
 
-  const result = await ingestor.ingestAll();
+  const embeddedDocs = await asyncIngestor.embedDocuments(SAMPLE_DOCS);
+  assert.equal(embeddedDocs.length, SAMPLE_DOCS.length);
+  assert.ok(Array.isArray(embeddedDocs[0].embedding));
+  assert.ok(asyncIngestor.embeddingClient, 'async embedding client should resolve automatically');
+});
 
-  assert.ok(result.count > 0, 'ingestion should create at least one document');
-  assert.equal(result.provider, 'memory', 'provider should be memory for tests');
-  assert.equal(vectorDb.records.length, result.count, 'vector DB should receive all embedded records');
-  assert.ok(vectorDb.records.every(record => Array.isArray(record.embedding) && record.embedding.length > 0), 'records should include embeddings');
-  assert.ok(vectorDb.records.every(record => typeof record.text === 'string' && record.text.length > 0), 'records should include serialized text');
+test('wtf-mcp ingest --dry-run completes without reference errors', async () => {
+  const cliPath = resolve(__dirname, '..', 'bin', 'wtf-mcp.js');
+  const { stdout } = await execFileAsync('node', [cliPath, 'ingest', '--dry-run'], {
+    env: {
+      ...process.env,
+      FORCE_COLOR: '0'
+    }
+  });
 
-  console.log(chalk.green(`✅ Ingestion succeeded with ${result.count} documents`));
-  console.log(chalk.gray(`Sample record: ${vectorDb.records[0].id}`));
-  console.log(chalk.cyan('\n🎯 Vector store ingestion tests completed!\n'));
-}
-
-runVectorStoreTests().catch((error) => {
-  console.error(chalk.red('❌ Vector store ingestion test failed:'), error);
-  process.exit(1);
+  assert.ok(/Dry run preview/.test(stdout), 'expected dry run preview output');
 });


### PR DESCRIPTION
## Summary
- consolidate the `wtf-mcp ingest` command to reuse the vector store ingestor with dry-run preview support
- expose reusable ingestion utilities in `lib/router/vector-store.js`, including a vector store client and helper functions
- convert the vector store tests to `node:test` and cover the CLI dry-run path

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1ebe5ca3c8326b1577dcdf4eeb465