### PR TITLE
Add WebSocket dynamic template and tests

### DIFF
--- a/lib/dynamic/mcp-generator.js
+++ b/lib/dynamic/mcp-generator.js
@@ -224,6 +224,198 @@ if __name__ == "__main__":
 `;
     }
 
+
+    if (filename.includes('websocket')) {
+      return `
+#!/usr/bin/env node
+
+/**
+ * Generated MCP Server for {{API_NAME}}
+ * Created: {{TIMESTAMP}}
+ * Type: WebSocket Bridge
+ */
+
+import { WebSocketServer, WebSocket } from 'ws';
+import { randomUUID } from 'node:crypto';
+
+class {{CLASS_NAME}}MCPServer {
+  constructor() {
+    this.port = {{PORT}};
+    this.apiBase = '{{API_BASE}}';
+    this.tools = [];
+    this.clients = new Map();
+  }
+
+  async initialize() {
+    console.error('📡 {{API_NAME}} WebSocket MCP Server starting...');
+    this.setupTools();
+    this.setupWebSocketServer();
+  }
+
+  setupTools() {
+    {{TOOLS_SETUP}}
+  }
+
+  setupWebSocketServer() {
+    this.wss = new WebSocketServer({ port: this.port });
+    this.wss.on('connection', (socket) => {
+      const clientId = randomUUID();
+      this.clients.set(clientId, socket);
+
+      socket.on('message', (data) => this.handleClientMessage(clientId, data));
+      socket.on('close', () => this.clients.delete(clientId));
+      socket.on('error', (error) => console.error('WebSocket error:', error));
+
+      socket.send(JSON.stringify({ type: 'connected', clientId }));
+    });
+
+    this.wss.on('listening', () => {
+      console.error(\`✅ WebSocket server listening on port \${this.port}\`);
+    });
+  }
+
+  sendToClient(clientId, payload) {
+    const socket = this.clients.get(clientId);
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      socket.send(JSON.stringify(payload));
+    }
+  }
+
+  broadcast(payload) {
+    const message = JSON.stringify(payload);
+    for (const socket of this.clients.values()) {
+      if (socket.readyState === WebSocket.OPEN) {
+        socket.send(message);
+      }
+    }
+  }
+
+  async handleClientMessage(clientId, data) {
+    try {
+      const raw = typeof data === 'string' ? data : data.toString('utf-8');
+      const message = JSON.parse(raw);
+      await this.handleWebSocketPayload(clientId, message);
+    } catch (error) {
+      console.error('Failed to process WebSocket message:', error);
+      this.sendToClient(clientId, {
+        type: 'error',
+        error: error instanceof Error ? error.message : 'Unknown error'
+      });
+    }
+  }
+
+  async handleWebSocketPayload(clientId, payload = {}) {
+    if (payload.type === 'ping') {
+      this.sendToClient(clientId, { type: 'pong', timestamp: Date.now() });
+      return;
+    }
+
+    if (payload.tool) {
+      const result = await this.handleRequest(payload.tool, payload.params || {});
+      this.sendToClient(clientId, {
+        type: 'toolResult',
+        tool: payload.tool,
+        result
+      });
+      return;
+    }
+
+    console.warn('Unhandled WebSocket payload', payload);
+  }
+
+  {{TOOL_METHODS}}
+
+  async handleRequest(method, params = {}) {
+    try {
+      switch (method) {
+        {{REQUEST_HANDLERS}}
+        default:
+          throw new Error(\`Unknown method: \${method}\`);
+      }
+    } catch (error) {
+      return { error: error instanceof Error ? error.message : String(error) };
+    }
+  }
+
+  async run() {
+    await this.initialize();
+
+    process.stdin.setEncoding('utf-8');
+    let buffer = '';
+
+    process.stdin.on('data', async (chunk) => {
+      buffer += chunk;
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+
+      for (const line of lines) {
+        if (line.trim()) {
+          try {
+            const request = JSON.parse(line);
+            await this.handleProtocol(request);
+          } catch (error) {
+            console.log(JSON.stringify({
+              jsonrpc: '2.0',
+              error: { code: -32700, message: 'Parse error' }
+            }));
+          }
+        }
+      }
+    });
+  }
+
+  async handleProtocol(request) {
+    if (request.method === 'initialize') {
+      console.log(JSON.stringify({
+        jsonrpc: '2.0',
+        id: request.id,
+        result: {
+          protocolVersion: '2024-11-05',
+          capabilities: { tools: {} },
+          serverInfo: { name: '{{API_NAME}}-websocket-mcp', version: '1.0.0' }
+        }
+      }));
+      return;
+    }
+
+    if (request.method === 'tools/list') {
+      console.log(JSON.stringify({
+        jsonrpc: '2.0',
+        id: request.id,
+        result: { tools: this.tools }
+      }));
+      return;
+    }
+
+    if (request.method === 'tools/call') {
+      const result = await this.handleRequest(request.params.name, request.params.arguments);
+      console.log(JSON.stringify({
+        jsonrpc: '2.0',
+        id: request.id,
+        result: {
+          content: [{
+            type: 'text',
+            text: JSON.stringify(result, null, 2)
+          }]
+        }
+      }));
+      return;
+    }
+
+    console.log(JSON.stringify({
+      jsonrpc: '2.0',
+      id: request.id,
+      error: { code: -32601, message: 'Method not found' }
+    }));
+  }
+}
+
+// Run the server
+const server = new {{CLASS_NAME}}MCPServer();
+server.run().catch(console.error);
+`;
+    }
+
     return '// Template not found';
   }
 
@@ -316,6 +508,18 @@ if __name__ == "__main__":
     }
 
     return code;
+  }
+
+  generateImports(templateType = 'rest') {
+    if (templateType === 'graphql') {
+      return "import { GraphQLClient } from 'graphql-request';";
+    }
+
+    if (templateType === 'websocket') {
+      return "import { WebSocketServer, WebSocket } from 'ws';";
+    }
+
+    return '';
   }
 
   generateTools(apiSpec, templateType = 'rest') {

--- a/lib/templates/websocket.js.template
+++ b/lib/templates/websocket.js.template
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+
+/**
+ * Generated MCP Server for {{API_NAME}}
+ * Created: {{TIMESTAMP}}
+ * Type: WebSocket Bridge
+ */
+
+import { WebSocketServer, WebSocket } from 'ws';
+import { randomUUID } from 'node:crypto';
+
+class {{CLASS_NAME}}MCPServer {
+  constructor() {
+    this.port = {{PORT}};
+    this.apiBase = '{{API_BASE}}';
+    this.tools = [];
+    this.clients = new Map();
+  }
+
+  async initialize() {
+    console.error('📡 {{API_NAME}} WebSocket MCP Server starting...');
+    this.setupTools();
+    this.setupWebSocketServer();
+  }
+
+  setupTools() {
+    {{TOOLS_SETUP}}
+  }
+
+  setupWebSocketServer() {
+    this.wss = new WebSocketServer({ port: this.port });
+    this.wss.on('connection', (socket) => {
+      const clientId = randomUUID();
+      this.clients.set(clientId, socket);
+
+      socket.on('message', (data) => this.handleClientMessage(clientId, data));
+      socket.on('close', () => this.clients.delete(clientId));
+      socket.on('error', (error) => console.error('WebSocket error:', error));
+
+      socket.send(JSON.stringify({ type: 'connected', clientId }));
+    });
+
+    this.wss.on('listening', () => {
+      console.error(`✅ WebSocket server listening on port ${this.port}`);
+    });
+  }
+
+  sendToClient(clientId, payload) {
+    const socket = this.clients.get(clientId);
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      socket.send(JSON.stringify(payload));
+    }
+  }
+
+  broadcast(payload) {
+    const message = JSON.stringify(payload);
+    for (const socket of this.clients.values()) {
+      if (socket.readyState === WebSocket.OPEN) {
+        socket.send(message);
+      }
+    }
+  }
+
+  async handleClientMessage(clientId, data) {
+    try {
+      const raw = typeof data === 'string' ? data : data.toString('utf-8');
+      const message = JSON.parse(raw);
+      await this.handleWebSocketPayload(clientId, message);
+    } catch (error) {
+      console.error('Failed to process WebSocket message:', error);
+      this.sendToClient(clientId, {
+        type: 'error',
+        error: error instanceof Error ? error.message : 'Unknown error'
+      });
+    }
+  }
+
+  async handleWebSocketPayload(clientId, payload = {}) {
+    if (payload.type === 'ping') {
+      this.sendToClient(clientId, { type: 'pong', timestamp: Date.now() });
+      return;
+    }
+
+    if (payload.tool) {
+      const result = await this.handleRequest(payload.tool, payload.params || {});
+      this.sendToClient(clientId, {
+        type: 'toolResult',
+        tool: payload.tool,
+        result
+      });
+      return;
+    }
+
+    console.warn('Unhandled WebSocket payload', payload);
+  }
+
+  {{TOOL_METHODS}}
+
+  async handleRequest(method, params = {}) {
+    try {
+      switch (method) {
+        {{REQUEST_HANDLERS}}
+        default:
+          throw new Error(`Unknown method: ${method}`);
+      }
+    } catch (error) {
+      return { error: error instanceof Error ? error.message : String(error) };
+    }
+  }
+
+  async run() {
+    await this.initialize();
+
+    process.stdin.setEncoding('utf-8');
+    let buffer = '';
+
+    process.stdin.on('data', async (chunk) => {
+      buffer += chunk;
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+
+      for (const line of lines) {
+        if (line.trim()) {
+          try {
+            const request = JSON.parse(line);
+            await this.handleProtocol(request);
+          } catch (error) {
+            console.log(JSON.stringify({
+              jsonrpc: '2.0',
+              error: { code: -32700, message: 'Parse error' }
+            }));
+          }
+        }
+      }
+    });
+  }
+
+  async handleProtocol(request) {
+    if (request.method === 'initialize') {
+      console.log(JSON.stringify({
+        jsonrpc: '2.0',
+        id: request.id,
+        result: {
+          protocolVersion: '2024-11-05',
+          capabilities: { tools: {} },
+          serverInfo: { name: '{{API_NAME}}-websocket-mcp', version: '1.0.0' }
+        }
+      }));
+      return;
+    }
+
+    if (request.method === 'tools/list') {
+      console.log(JSON.stringify({
+        jsonrpc: '2.0',
+        id: request.id,
+        result: { tools: this.tools }
+      }));
+      return;
+    }
+
+    if (request.method === 'tools/call') {
+      const result = await this.handleRequest(request.params.name, request.params.arguments);
+      console.log(JSON.stringify({
+        jsonrpc: '2.0',
+        id: request.id,
+        result: {
+          content: [{
+            type: 'text',
+            text: JSON.stringify(result, null, 2)
+          }]
+        }
+      }));
+      return;
+    }
+
+    console.log(JSON.stringify({
+      jsonrpc: '2.0',
+      id: request.id,
+      error: { code: -32601, message: 'Method not found' }
+    }));
+  }
+}
+
+// Run the server
+const server = new {{CLASS_NAME}}MCPServer();
+server.run().catch(console.error);
+

--- a/test/dynamic-websocket.test.js
+++ b/test/dynamic-websocket.test.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { DynamicMCPGenerator } from '../lib/dynamic/mcp-generator.js';
+
+test('dynamic generator produces websocket scaffold', async () => {
+  const generator = new DynamicMCPGenerator();
+  await generator.init();
+
+  const template = generator.templates.get('websocket');
+  assert.ok(template, 'expected websocket template to be registered');
+
+  const spec = {
+    name: 'ws-echo',
+    description: 'Echo websocket service',
+    websocket: {
+      url: 'wss://example.com/socket',
+      protocols: ['json']
+    },
+    endpoints: []
+  };
+
+  const code = await generator.generateCode(spec, template);
+
+  assert.match(code, /WebSocketServer/);
+  assert.match(code, /setupWebSocketServer/);
+  assert.match(code, /handleWebSocketPayload/);
+  assert.doesNotMatch(code, /Template not found/);
+});
+


### PR DESCRIPTION
## Summary
- add a dedicated websocket server template and default fallback for dynamic MCP generation
- ensure template registration provides imports and websocket scaffolding
- add a generation test that verifies websocket code replaces the placeholder output

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1ebef0ae08326bf0c66c1cec1f303