### PR TITLE
Fix registry ingestion to use normalized entries

### DIFF
--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -207,9 +207,10 @@ class WTFMCPManagerServer {
       const dataHash = createHash('sha256').update(text).digest('hex');
       const shouldIndex = force || this.registryIndexHash !== dataHash || !this.vectorRouter.isAvailable?.();
       let ingestionResult = null;
+      let indexed = false;
 
-      if (shouldIndex && normalizedRecords.length > 0 && typeof this.vectorRouter?.ingestTools === 'function') {
-        const ingestionResult = await this.vectorRouter.ingestTools(normalizedRecords, { force: true });
+      if (shouldIndex && normalizedEntries.length > 0 && typeof this.vectorRouter?.ingestTools === 'function') {
+        ingestionResult = await this.vectorRouter.ingestTools(normalizedEntries, { force: true });
         indexed = (ingestionResult?.ingested || 0) > 0;
 
         if (indexed) {


### PR DESCRIPTION
## Summary
- correct the MCP registry ingestion flow to use the normalized entries array
- initialize the indexed flag before use and avoid shadowing the ingestion result variable

## Testing
- npm test -- fetch_mcps *(fails: SyntaxError: Identifier 'collectMCPMetadata' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_68e1f17505b88326ae62ea06b9059d8f