### PR TITLE
Fix registry ingestion to use normalized entries

### DIFF
--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -206,10 +206,11 @@ class WTFMCPManagerServer {
 
       const dataHash = createHash('sha256').update(text).digest('hex');
       const shouldIndex = force || this.registryIndexHash !== dataHash || !this.vectorRouter.isAvailable?.();
+      let indexed = false;
       let ingestionResult = null;
 
-      if (shouldIndex && normalizedRecords.length > 0 && typeof this.vectorRouter?.ingestTools === 'function') {
-        const ingestionResult = await this.vectorRouter.ingestTools(normalizedRecords, { force: true });
+      if (shouldIndex && normalizedEntries.length > 0 && typeof this.vectorRouter?.ingestTools === 'function') {
+        ingestionResult = await this.vectorRouter.ingestTools(normalizedEntries, { force: true });
         indexed = (ingestionResult?.ingested || 0) > 0;
 
         if (indexed) {


### PR DESCRIPTION
## Summary
- ensure MCP registry ingestion uses the normalizedEntries array instead of an undefined variable
- initialize the indexed flag before use and reuse the existing ingestionResult reference to avoid shadowing

## Testing
- npm test -- fetch_mcps *(fails: SyntaxError Identifier 'collectMCPMetadata' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_68e1f1ab20008326b5701a479f831e8b